### PR TITLE
TASK-35389: Save connected google account and synchronize between browsers

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/CalendarService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/CalendarService.js
@@ -81,3 +81,41 @@ export function getAgendaSettings() {
     return resp;
   });
 }
+export function saveAgendaConnectorsSettings(settingsValues) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/settings/USER,${eXo.env.portal.userName}/APPLICATION,Agenda/agendaConnectorsSettings`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      value: JSON.stringify(settingsValues),
+    }),
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Error saving agenda settings', resp);
+    }
+  });
+}
+
+export function getAgendaConnectorsSettings() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/settings/USER,${eXo.env.portal.userName}/APPLICATION,Agenda/agendaConnectorsSettings`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.json();
+    } else if (resp && resp.status === 404) {
+      return null;
+    } else {
+      throw new Error('Error getting agenda settings');
+    }
+  }).then(resp => {
+    return resp;
+  });
+}

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-connectors/agendaGoogleConnector.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-connectors/agendaGoogleConnector.js
@@ -5,6 +5,7 @@ export default {
   DISCOVERY_DOCS: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
   SCOPES: 'https://www.googleapis.com/auth/calendar.readonly',
   initialized: false,
+  isSignedIn: false,
   init(connectionStatusChangedCallback, loadingCallback) {
     // Already initialized
     if (this.initialized) {
@@ -18,6 +19,7 @@ export default {
     // Called when the signed in status changes, to update the UI
     // appropriately. After a sign-in, the API is called.
     function updateSigninStatus(isSignedIn) {
+      self_.isSignedIn = isSignedIn;
       try {
         if (isSignedIn) {
           const currentUser = self_.gapi.auth2.getAuthInstance().currentUser.get();
@@ -55,10 +57,10 @@ export default {
   },
   connect() {
     this.loadingCallback(this, true);
-    this.gapi.auth2.getAuthInstance().signIn();
+    return this.gapi.auth2.getAuthInstance().signIn();
   },
   disconnect() {
     this.loadingCallback(this, true);
-    this.gapi.auth2.getAuthInstance().signOut();
-  },
+    return this.gapi.auth2.getAuthInstance().signOut();
+  }
 };

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserConnectorSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserConnectorSettings.vue
@@ -6,9 +6,24 @@
           {{ skeleton && '&nbsp;' || $t('agenda.connectYourPersonalAgenda') }}
         </div>
       </v-list-item-title>
-      <v-list-item-subtitle class="text-sub-title font-italic">
-        <div :class="skeleton && 'skeleton-background skeleton-border-radius skeleton-text-width-small skeleton-text-height-fine my-2'">
-          {{ skeleton && '&nbsp;' || connectedAccountName || $t('agenda.connectYourPersonalAgendaSubTitle') }}
+      <v-list-item-subtitle class="mx-7 my-3 text-sub-title font-italic">
+        <div
+          v-if="connectedAccountName">
+          <v-avatar tile size="24">
+            <img
+              :alt="connectedAccount.name"
+              :src="connectedAccountIconSource">
+          </v-avatar>
+          <a
+            class="mx-2"
+            @click="openDrawer">
+            {{ connectedAccountName }}
+          </a>
+        </div>
+        <div
+          v-else
+          :class="skeleton && 'skeleton-background skeleton-border-radius skeleton-text-width-small skeleton-text-height-fine my-2'">
+          {{ skeleton && '&nbsp;' || $t('agenda.connectYourPersonalAgendaSubTitle') }}
         </div>
       </v-list-item-subtitle>
     </v-list-item-content>
@@ -21,7 +36,7 @@
         <i v-if="!skeleton" class="uiIconEdit uiIconLightBlue pb-2"></i>
       </v-btn>
     </v-list-item-action>
-    <agenda-user-connected-account-drawer />
+    <agenda-user-connected-account-drawer :connected-account="connectedAccount" />
   </v-list-item>
 </template>
 
@@ -34,19 +49,30 @@ export default {
     },
   },
   data: () => ({
-    connectedAccount: null,
+    connectedAccount: {},
   }),
   computed: {
     connectedAccountName() {
-      return this.connectedAccount && this.connectedAccount.name || '';
+      return this.connectedAccount && this.connectedAccount.userId || '';
     },
-    connectedAccountIconClass() {
-      return this.connectedAccount && this.connectedAccount.iconClass || '';
+    connectedAccountIconSource() {
+      return this.connectedAccount && this.connectedAccount.icon || '';
     },
   },
+  created() {
+    this.$root.$on('agenda-refresh', this.refresh);
+    this.refresh();
+  },
   methods: {
+    refresh() {
+      this.$calendarService.getAgendaConnectorsSettings().then(connectorSettings => {
+        if (connectorSettings && connectorSettings.value) {
+          this.connectedAccount = JSON.parse(connectorSettings.value);
+        }
+      });
+    },
     openDrawer() {
-      this.$root.$emit('agenda-connected-account-settings-open', this.connectedAccount);
+      this.$root.$emit('agenda-connected-account-settings-open');
     },
     getDayFromAbbreviation(day) {
       return this.$agendaUtils.getDayNameFromDayAbbreviation(day, eXo.env.portal.language);


### PR DESCRIPTION
When a user connect to his google account from a first browser, we save his email as `userId`. Then when he tries to open the platform from an other browser, we show him the associated account. a disconnect from any browser clears the information from database.