### PR TITLE
Remove Event modifier from event notification

### DIFF
--- a/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeService.java
+++ b/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeService.java
@@ -37,13 +37,15 @@ public interface AgendaEventAttendeeService {
   public List<EventAttendee> getEventAttendees(long eventId);
 
   /**
-   * Sends an invitation to event attendees of type: user, space or external user.
+   * Sends an invitation to event attendees of type: user, space or external
+   * user.
    * 
-   * @param eventId technical identifier of the event
+   * @param event {@link Event}
+   * @param eventAttendees {@link List} of {@link EventAttendee} of the event
    * @param eventModificationType flag to indicate if event is added, updated or
    *          deleted
    */
-  public void sendInvitations(long eventId, EventModificationType eventModificationType);
+  public void sendInvitations(Event event, List<EventAttendee> eventAttendees, EventModificationType eventModificationType);
 
   /**
    * @param event {@link Event} to attach attendees

--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/plugin/AgendaNotificationPlugin.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/plugin/AgendaNotificationPlugin.java
@@ -64,7 +64,7 @@ public class AgendaNotificationPlugin extends BaseNotificationPlugin {
   @Override
   public NotificationInfo makeNotification(NotificationContext ctx) {
     @SuppressWarnings("unchecked")
-    List<EventAttendee> eventAttendee = ctx.value(EVENT_ATTENDEE);
+    List<EventAttendee> eventAttendees = ctx.value(EVENT_ATTENDEE);
     Event event = ctx.value(EVENT_AGENDA);
     String typeModification = ctx.value(EVENT_MODIFICATION_TYPE);
     // To avoid NPE for previously stored notifications, if
@@ -76,7 +76,7 @@ public class AgendaNotificationPlugin extends BaseNotificationPlugin {
     NotificationInfo notification = NotificationInfo.instance();
     notification.key(getId());
     if (event.getId() > 0) {
-      setNotificationRecipients(identityManager, notification, spaceService, eventAttendee, event, typeModification);
+      setNotificationRecipients(identityManager, notification, spaceService, eventAttendees, event, typeModification);
     }
     if (notification.getSendToUserIds() == null || notification.getSendToUserIds().isEmpty()) {
       LOG.debug("Notification type '{}' doesn't have a recipient", getId());

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeServiceImpl.java
@@ -126,7 +126,10 @@ public class AgendaEventAttendeeServiceImpl implements AgendaEventAttendeeServic
         try {
           sendEventResponse(eventId, eventAttendee.getIdentityId(), EventAttendeeResponse.NEEDS_ACTION);
         } catch (Exception e) {
-          LOG.warn("Error initializing default reminders of event {} for user with id {}", eventId, eventAttendee.getIdentityId(), e);
+          LOG.warn("Error initializing default reminders of event {} for user with id {}",
+                   eventId,
+                   eventAttendee.getIdentityId(),
+                   e);
         }
       }
     }
@@ -146,7 +149,10 @@ public class AgendaEventAttendeeServiceImpl implements AgendaEventAttendeeServic
     }
 
     if (sendInvitations) {
-      sendInvitations(eventId, eventModificationType);
+      if (event.getStatus() == EventStatus.CANCELLED) {
+        eventModificationType = EventModificationType.DELETED;
+      }
+      sendInvitations(event, attendees, eventModificationType);
     }
 
     Utils.broadcastEvent(listenerService, "exo.agenda.event.attendees.saved", eventId, 0);
@@ -291,11 +297,9 @@ public class AgendaEventAttendeeServiceImpl implements AgendaEventAttendeeServic
    * {@inheritDoc}
    */
   @Override
-  public void sendInvitations(long eventId, EventModificationType eventModificationType) {
+  public void sendInvitations(Event event, List<EventAttendee> eventAttendees, EventModificationType eventModificationType) {
     String agendaNotificationPluginType = null;
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
-    Event event = eventStorage.getEventById(eventId);
-    List<EventAttendee> eventAttendees = getEventAttendees(eventId);
     ctx.append(EVENT_AGENDA, event);
     ctx.append(EVENT_ATTENDEE, eventAttendees);
     if (eventModificationType.name().equals("ADDED")) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
@@ -647,7 +647,8 @@ public class AgendaEventServiceImpl implements AgendaEventService {
     agendaEventStorage.updateEvent(event);
 
     if (sendInvitations) {
-      attendeeService.sendInvitations(eventId, EventModificationType.UPDATED);
+      List<EventAttendee> eventAttendees = attendeeService.getEventAttendees(eventId);
+      attendeeService.sendInvitations(event, eventAttendees, EventModificationType.UPDATED);
     }
 
     Utils.broadcastEvent(listenerService, Utils.POST_UPDATE_AGENDA_EVENT_EVENT, eventId, 0);
@@ -671,10 +672,14 @@ public class AgendaEventServiceImpl implements AgendaEventService {
     if (!canUpdateEvent(event, userIdentityId)) {
       throw new IllegalAccessException("User " + userIdentityId + " hasn't enough privileges to delete event with id " + eventId);
     }
-    attendeeService.sendInvitations(eventId, EventModificationType.DELETED);
+    List<EventAttendee> eventAttendees = attendeeService.getEventAttendees(event.getId());
+
     agendaEventStorage.deleteEventById(eventId);
 
-    Utils.broadcastEvent(listenerService, Utils.POST_DELETE_AGENDA_EVENT_EVENT, eventId, 0);
+    event.setModifierId(userIdentityId);
+    attendeeService.sendInvitations(event, eventAttendees, EventModificationType.DELETED);
+
+    Utils.broadcastEvent(listenerService, Utils.POST_DELETE_AGENDA_EVENT_EVENT, eventId, event);
     return event;
   }
 


### PR DESCRIPTION
When deleting an event, the modifier shouldn't be notified