### PR TITLE
Fix initializing agenda Remote Provider with empty database

### DIFF
--- a/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaRemoteEventService.java
+++ b/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaRemoteEventService.java
@@ -1,7 +1,6 @@
 package org.exoplatform.agenda.service;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.exoplatform.agenda.model.*;
 import org.exoplatform.agenda.plugin.RemoteProviderDefinitionPlugin;
@@ -13,9 +12,16 @@ public interface AgendaRemoteEventService {
    * Register a new Remote provider
    * 
    * @param plugin {@link RemoteProviderDefinitionPlugin}
-   * @return {@link CompletableFuture} of created {@link RemoteProvider}
    */
-  CompletableFuture<RemoteProvider> addRemoteProvider(RemoteProviderDefinitionPlugin plugin);
+  void addRemoteProvider(RemoteProviderDefinitionPlugin plugin);
+
+  /**
+   * Register a new Remote provider
+   * 
+   * @param plugin {@link RemoteProviderDefinitionPlugin}
+   * @return created {@link RemoteProvider}
+   */
+  RemoteProvider saveRemoteProviderPlugin(RemoteProviderDefinitionPlugin plugin);
 
   /**
    * @return {@link List} of available events {@link RemoteProvider}

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaRemoteEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaRemoteEventServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.*;
 
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.codec.binary.StringUtils;
 import org.junit.Test;
@@ -30,9 +29,7 @@ public class AgendaRemoteEventServiceTest extends BaseAgendaEventTest {
     params.addParameter(param);
     RemoteProviderDefinitionPlugin plugin = new RemoteProviderDefinitionPlugin(params);
 
-    CompletableFuture<RemoteProvider> addedRemoteProviderFuture = agendaRemoteEventService.addRemoteProvider(plugin);
-    assertNotNull(addedRemoteProviderFuture);
-    RemoteProvider addedRemoteProvider = addedRemoteProviderFuture.get();
+    RemoteProvider addedRemoteProvider = agendaRemoteEventService.saveRemoteProviderPlugin(plugin);
     assertNotNull(addedRemoteProvider);
     assertTrue(addedRemoteProvider.getId() > 0);
     assertFalse(addedRemoteProvider.isEnabled());


### PR DESCRIPTION
When starting a fresh Server with empty database, the remote providers aren't initialized and no exception gets logged because the database isn't initialized yet. This fix ensures to inject remote providers after Portal container is started and thus the database is initialized.