### PR TITLE
38505 : Fix generating Space Avatar URL in Invitation Mail Notification

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
@@ -23,6 +23,7 @@ import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 import groovy.text.GStringTemplateEngine;
 import groovy.text.Template;
@@ -36,6 +37,8 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
   private AgendaEventAttendeeService agendaEventAttendeeService;
 
   private AgendaUserSettingsService  agendaUserSettingsService;
+
+  private SpaceService               spaceService;
 
   private IdentityManager            identityManager;
 
@@ -95,6 +98,7 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
           || agendaUserSettings.getTimeZoneId() == null ? ZoneOffset.UTC : ZoneId.of(agendaUserSettings.getTimeZoneId());
 
       TemplateContext templateContext = buildTemplateParameters(username,
+                                                                getSpaceService(),
                                                                 getAgendaEventAttendeeService(),
                                                                 templateProvider,
                                                                 notification,
@@ -166,5 +170,12 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
       identityManager = this.container.getComponentInstanceOfType(IdentityManager.class);
     }
     return identityManager;
+  }
+
+  public SpaceService getSpaceService() {
+    if (spaceService == null) {
+      spaceService = this.container.getComponentInstanceOfType(SpaceService.class);
+    }
+    return spaceService;
   }
 }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/ReminderTemplateBuilder.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/ReminderTemplateBuilder.java
@@ -25,6 +25,7 @@ import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 import groovy.text.GStringTemplateEngine;
 import groovy.text.Template;
@@ -35,6 +36,8 @@ public class ReminderTemplateBuilder extends AbstractTemplateBuilder {
   private AgendaEventService        agendaEventService;
 
   private AgendaUserSettingsService agendaUserSettingsService;
+
+  private SpaceService              spaceService;
 
   private IdentityManager           identityManager;
 
@@ -92,7 +95,10 @@ public class ReminderTemplateBuilder extends AbstractTemplateBuilder {
       ZoneId timeZone = agendaUserSettings == null
           || agendaUserSettings.getTimeZoneId() == null ? ZoneOffset.UTC : ZoneId.of(agendaUserSettings.getTimeZoneId());
 
-      TemplateContext templateContext = buildTemplateReminderParameters(templateProvider, notification, timeZone);
+      TemplateContext templateContext = buildTemplateReminderParameters(getSpaceService(),
+                                                                        templateProvider,
+                                                                        notification,
+                                                                        timeZone);
       MessageInfo messageInfo = buildMessageSubjectAndBody(templateContext, notification, pushNotificationURL);
       Throwable exception = templateContext.getException();
       logException(notification, exception);
@@ -159,4 +165,10 @@ public class ReminderTemplateBuilder extends AbstractTemplateBuilder {
     return identityManager;
   }
 
+  public SpaceService getSpaceService() {
+    if (spaceService == null) {
+      spaceService = this.container.getComponentInstanceOfType(SpaceService.class);
+    }
+    return spaceService;
+  }
 }


### PR DESCRIPTION
The generated Mail Notification for event notification uses a relative Avatar URL. This fix will change it by re-using an existing method to generate Absolute Space Avatar URL