### PR TITLE
38504 : Fix Agenda Timeline Widget permission on space to allow external users access it

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaSpaceApplicationListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaSpaceApplicationListener.java
@@ -26,7 +26,7 @@ import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent.Type;
 
 public class AgendaSpaceApplicationListener implements SpaceLifeCycleListener {
 
-  private static final String[] AGENDA_TIMELINE_APPLICATION_ACCESS_PERMISSIONS = new String[] { "*:/platform/users" };
+  private static final String[] AGENDA_TIMELINE_APPLICATION_ACCESS_PERMISSIONS = new String[] { "Everyone" };
 
   public static final String AGENDA_APPLICATION_INSTALLED_EVENT_NAME = "agenda.space.application.installed";
 


### PR DESCRIPTION
to allow users access Agenda application, the permission has to change to everyone when installing agenda Timeline application

