### PR TITLE
38634 : Fix Agenda Event View style

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetails.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetails.vue
@@ -71,7 +71,7 @@
         <div v-if="canAddReminders" class="event-reminders align-center d-flex pb-5 text-truncate">
           <i class="uiIcon32x32 notifIcon darkGreyIcon pr-5 mt-1 mb-auto"></i>
           <v-list
-            class="py-0"
+            class="py-0 text-truncate"
             dense>
             <v-list-item v-if="!event.reminders || !event.reminders.length">
               <label class="text-sub-title font-italic mx-auto">
@@ -88,7 +88,7 @@
                   class="mt-1 mb-2 mr-2"
                   color="primary"
                   outlined>
-                  <span class="text--primary">
+                  <span class="text--primary text-truncate">
                     <template v-if="reminder.before">
                       {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
                     </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorContemporaryEvents.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorContemporaryEvents.vue
@@ -9,14 +9,14 @@
         <img :src="connectedConnectorAvatar">
       </v-avatar>
       <i v-else class="uiIconCalRemoteCalendar darkGreyIcon uiIcon24x24 pr-2 pt-2"></i>
-      <div class="d-flex flex-column remote-events-details">
-        <div class="d-flex">
+      <div class="d-flex flex-column">
+        <div class="d-flex text-no-wrap text-truncate">
           {{ $t('agenda.personalCalendar') }}
           {{ ' ( ' }}
           <date-format
             :value="event.startDate"
             :format="fullDateFormat"
-            class="mr-1" />
+            class="mr-1 text-wrap center" />
           {{ ' ) ' }}
         </div>
         <a
@@ -40,7 +40,7 @@
               :remote-event="remoteEvent"
               :avatar="connectedConnectorAvatar"
               :event="event"
-              class="mt-5"
+              class="mt-5 remote-events-details"
               is-events-list />
           </template>
           <v-chip


### PR DESCRIPTION
When displaying event view, and especially when connecting a Remote Google Calendar, the style of current date isn't well displayed. In addition, in mobile, we can't access the reminders drawer button because the reminders doesn't apply an ellipsis