### PR TITLE
39279 : Fix TimeZone of event when pushing to Remote Calendar

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/AgendaDateUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/AgendaDateUtils.java
@@ -80,14 +80,14 @@ public class AgendaDateUtils {
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 
-  public static String toRFC3339Date(ZonedDateTime zonedDateTime, boolean allDay) {
+  public static String toRFC3339Date(ZonedDateTime zonedDateTime, ZoneId zoneOffset, boolean allDay) {
     if (zonedDateTime == null) {
       return null;
     }
     if (allDay) {
-      return zonedDateTime.format(ALL_DAY_FORMATTER);
+      return zonedDateTime.withZoneSameLocal(zoneOffset).format(ALL_DAY_FORMATTER);
     } else {
-      return zonedDateTime.format(RFC_3339_FORMATTER);
+      return zonedDateTime.withZoneSameInstant(zoneOffset).format(RFC_3339_FORMATTER);
     }
   }
 

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -1529,24 +1529,24 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
     assertEquals(fieldValue, event.getTimeZoneId().getId());
 
     fieldName = "start";
-    fieldValue = AgendaDateUtils.toRFC3339Date(start.minusDays(1), allDay);
+    fieldValue = AgendaDateUtils.toRFC3339Date(start.minusDays(1), ZoneId.systemDefault(), allDay);
     agendaEventService.updateEventFields(eventId,
                                          getFields(fieldName, fieldValue),
                                          true,
                                          true,
                                          Long.parseLong(testuser1Identity.getId()));
     event = agendaEventService.getEventById(eventId);
-    assertEquals(fieldValue, AgendaDateUtils.toRFC3339Date(event.getStart(), allDay));
+    assertEquals(fieldValue, AgendaDateUtils.toRFC3339Date(event.getStart(), ZoneId.systemDefault(), allDay));
 
     fieldName = "end";
-    fieldValue = AgendaDateUtils.toRFC3339Date(start.plusDays(2), allDay);
+    fieldValue = AgendaDateUtils.toRFC3339Date(start.plusDays(2), ZoneId.systemDefault(), allDay);
     agendaEventService.updateEventFields(eventId,
                                          getFields(fieldName, fieldValue),
                                          true,
                                          true,
                                          Long.parseLong(testuser1Identity.getId()));
     event = agendaEventService.getEventById(eventId);
-    assertEquals(fieldValue, AgendaDateUtils.toRFC3339Date(event.getEnd(), allDay));
+    assertEquals(fieldValue, AgendaDateUtils.toRFC3339Date(event.getEnd(), ZoneId.systemDefault(), allDay));
 
     fieldName = "allDay";
     fieldValue = String.valueOf(!allDay);


### PR DESCRIPTION
When pushing a recurrent event that will happen after few dates to Remote Calendar (Google for example), the used timeZone of the Event that is pushed is UTC.
This PR will ensure to retrieve the right dates of event converted to user TimeZone.