### PR TITLE
39277 : Add break Text on Event Details fields

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -390,6 +390,10 @@
     color: @darkGrey !important;
   }
 
+  .text-wrap a {
+    word-break: break-word;
+  }
+
   .event-details-body {
     .event-details-body-right, .event-details-body-left {
       max-width: ~"calc(50% - 21px)";

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetails.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetails.vue
@@ -110,15 +110,15 @@
         </div>
         <div v-if="isConferenceEnabled" class="event-conference d-flex flex-grow-0 flex-shrink-1 pb-5">
           <i class="uiIconVideo darkGreyIcon uiIcon32x32 pr-5"></i>
-          <span v-autolinker="eventConferenceUrl" class="align-self-center"></span>
+          <span v-autolinker="eventConferenceUrl" class="align-self-center text-break"></span>
         </div>
         <div v-if="event.location" class="event-location d-flex flex-grow-0 flex-shrink-1 pb-5">
           <i class="uiIconCheckin darkGreyIcon uiIcon32x32 pr-5"></i>
-          <span v-autolinker="event.location" class="align-self-center"></span>
+          <span v-autolinker="event.location" class="align-self-center text-break"></span>
         </div>
         <div v-if="event.description" class="event-description d-flex flex-grow-0 flex-shrink-1 pb-5">
           <i class="uiIconDescription darkGreyIcon uiIcon32x32 pr-5"></i>
-          <span v-autolinker="event.description" class="mt-1 align-self-center text-wrap text-left"></span>
+          <span v-autolinker="event.description" class="mt-1 align-self-center text-wrap text-left text-break"></span>
         </div>
         <div
           v-if="event.attachments && event.attachments.length !== 0"


### PR DESCRIPTION
When having a long link inside Description, Conference link or Location, the text isn't splitted into a new line. By adding text-break CSS Class, this allows to return to a new line when the link exceeds field borders.