### PR TITLE
39313 : Avoid displaying confirm dialog when clicking on more options

### DIFF
--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -1073,7 +1073,7 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
     try {
       Event event = new Event();
       event.setId(eventId);
-      event.setCalendarId(12);
+      event.setCalendarId(1200);
       event.setStart(ZonedDateTime.now());
       event.setEnd(ZonedDateTime.now());
       EventRecurrence recurrence = new EventRecurrence();

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -212,8 +212,9 @@ export default {
       this.event.start = this.$agendaUtils.toRFC3339(this.event.startDate);
       this.event.end = this.$agendaUtils.toRFC3339(this.event.endDate);
 
-      this.$refs.quickAddEventDrawer.close();
       this.$root.$emit('agenda-event-form', this.event);
+      this.event = null;
+      this.$nextTick(() => this.$refs.quickAddEventDrawer.close());
     },
     resetCustomValidity() {
       if (this.$refs.eventTitle) {


### PR DESCRIPTION
Use case:
1/ Use quick add event form (Click on Agenda Area)
2/ Enter a title
3/ Click on 'More options' button
Result: the event form is displayed with a popin that asks user whether to cancel modifications or not.

This is due to the fact that the Drawer is closed while there is a modification made. This fix ensures to purge current event that has been changed in drawer before opening complete form dialog