### PR TITLE
39494 : Fix computing reminder dates when updating event

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
@@ -582,6 +582,11 @@ public class AgendaEventServiceImpl implements AgendaEventService {
                                        false,
                                        EventModificationType.UPDATED);
 
+    if (!storedEvent.getStart().equals(updatedEvent.getStart())) {
+      List<EventReminder> allReminders = reminderService.getEventReminders(eventId);
+      reminderService.saveEventReminders(updatedEvent, allReminders);
+    }
+
     Utils.broadcastEvent(listenerService, Utils.POST_UPDATE_AGENDA_EVENT_EVENT, eventId, 0);
 
     return updatedEvent;


### PR DESCRIPTION
Use case:
1/ Create an event and ensure that you have reminders on it
2/ Add user participant to the event
3/ Login with user participant and accept event
4/ Login with event creator and modify event start date

=> Result: reminder is sent at previous time instead of new one for participant
This PR ensures to update reminder trigger date even when updating start date