### PR TITLE
TASK-39002: fix send invitation by select all space

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventReplyListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventReplyListener.java
@@ -32,11 +32,11 @@ public class AgendaEventReplyListener extends Listener<EventAttendee, EventAtten
       EventAttendee oldAttendee = event.getSource();
       EventAttendee newAttendee = event.getData();
       org.exoplatform.agenda.model.Event agendaEvent = getAgendaEventService().getEventById(newAttendee.getEventId());
+      EventAttendeeResponse oldResponse = oldAttendee == null ? null : oldAttendee.getResponse();
+      EventAttendeeResponse newResponse = newAttendee.getResponse();
       // Avoid notifying creator when he changes his response and avoid
       // notifying him when a user doesn't change his response
-      if ((oldAttendee == null && agendaEvent.getCreatorId() != newAttendee.getIdentityId())
-          || (oldAttendee.getResponse() != newAttendee.getResponse()
-              && agendaEvent.getCreatorId() != oldAttendee.getIdentityId())) {
+      if (oldResponse != newResponse && agendaEvent.getCreatorId() != newAttendee.getIdentityId()) {
         sendReplyResponseNotification(agendaEvent, newAttendee.getIdentityId(), newAttendee.getResponse());
       }
     } finally {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventReplyListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventReplyListener.java
@@ -31,11 +31,13 @@ public class AgendaEventReplyListener extends Listener<EventAttendee, EventAtten
     try {
       EventAttendee oldAttendee = event.getSource();
       EventAttendee newAttendee = event.getData();
-      org.exoplatform.agenda.model.Event agendaEvent = getAgendaEventService().getEventById(oldAttendee.getEventId());
+      org.exoplatform.agenda.model.Event agendaEvent = getAgendaEventService().getEventById(newAttendee.getEventId());
       // Avoid notifying creator when he changes his response and avoid
       // notifying him when a user doesn't change his response
-      if (oldAttendee.getResponse() != newAttendee.getResponse() && agendaEvent.getCreatorId() != oldAttendee.getIdentityId()) {
-        sendReplyResponseNotification(agendaEvent, oldAttendee.getIdentityId(), newAttendee.getResponse());
+      if ((oldAttendee == null && agendaEvent.getCreatorId() != newAttendee.getIdentityId())
+          || (oldAttendee.getResponse() != newAttendee.getResponse()
+              && agendaEvent.getCreatorId() != oldAttendee.getIdentityId())) {
+        sendReplyResponseNotification(agendaEvent, newAttendee.getIdentityId(), newAttendee.getResponse());
       }
     } finally {
       RequestLifeCycle.end();

--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/templates/notification/web/EventReplyWebPlugin.gtmpl
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/templates/notification/web/EventReplyWebPlugin.gtmpl
@@ -8,7 +8,7 @@
             <div class="contentSmall" data-link="<%= eventURL %>">
                 <div class="status">
                     <%
-                    String eventTitle = "<span class=\"user-name text-bold\">"+ eventTitle +"</span>";
+                    String eventTitle = "<span class=\"user-name  text-truncate text-bold\">"+ eventTitle +"</span>";
                     String participantName = "<a class=\"user-name text-bold\">" + participantName +"</a>";
                     if (org.exoplatform.agenda.constant.EventAttendeeResponse.ACCEPTED.name().equals(responseType)) { %>
                       <%= _ctx.appRes("Notification.agenda.event.response.accepted", participantName, eventTitle) %>


### PR DESCRIPTION
When we select space in participant, you didn't send the response of the attendee for the first time.
**Problem:** for the first time,  old attendee is null
**Solution:** we use newAttendee to get identity of attendee and add in condition oldAtendee == null to cover this case