### PR TITLE
TASK-39340: Remove popin date in second stepper of create an event

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
@@ -157,7 +157,7 @@ export default {
       return this.displayTimeInForm || this.stepper > 1;
     },
     disableCreateButton() {
-      return !this.eventTitleValid || !this.eventOwnerValid || !this.eventDescriptionValid || !this.eventDateValid;
+      return !this.eventTitleValid || !this.eventOwnerValid || !this.eventDescriptionValid || (!this.eventDateValid && this.stepper > 1);
     },
     nextStepClass() {
       return this.displayTimeInForm && 'btn primary' || 'btn btn-primary';

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
@@ -67,15 +67,15 @@
       </v-btn>
       <div class="ml-auto mr-10">
         <v-btn
-          v-if="displaySaveButton"
-          :disabled="disableSaveButton"
+          v-if="displayCreateButton"
+          :disabled="disableCreateButton"
           class="btn btn-primary mr-2"
           @click="saveEvent">
-          {{ $t('agenda.button.save') }}
+          {{ $t('agenda.label.create') }}
         </v-btn>
         <v-btn
           v-if="stepper < 2"
-          :disabled="disableSaveButton"
+          :disabled="disableCreateButton"
           :outlined="displayTimeInForm"
           :class="nextStepClass"
           @click="nextStep">
@@ -138,6 +138,9 @@ export default {
     eventTitleValid() {
       return this.eventTitle && this.eventTitle.length >= 5 && this.eventTitle.length < 1024;
     },
+    eventDateValid() {
+      return this.event && this.event.startDate;
+    },
     eventOwner() {
       return this.event && this.event.calendar && this.event.calendar.owner;
     },
@@ -150,11 +153,11 @@ export default {
     eventDescriptionValid() {
       return this.eventDescription.length <= 1300;
     },
-    displaySaveButton() {
+    displayCreateButton() {
       return this.displayTimeInForm || this.stepper > 1;
     },
-    disableSaveButton() {
-      return !this.eventTitleValid || !this.eventOwnerValid || !this.eventDescriptionValid;
+    disableCreateButton() {
+      return !this.eventTitleValid || !this.eventOwnerValid || !this.eventDescriptionValid || !this.eventDateValid;
     },
     nextStepClass() {
       return this.displayTimeInForm && 'btn primary' || 'btn btn-primary';

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDates.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDates.vue
@@ -56,8 +56,6 @@
       event-end="endDate"
       color="primary"
       type="week"
-      @click:event="showEvent"
-      @mousedown:event="showEvent"
       @mousedown:time="startTime"
       @mousemove:time="mouseMove"
       @mouseup:time="endDrag"
@@ -67,7 +65,7 @@
         <div
           v-if="!eventObj.event || eventObj.event.type !== 'remoteEvent'"
           :id="getEventDomId(eventObj)"
-          class="v-event-draggable v-event-draggable-parent">
+          class="readonly-event">
           <p
             :title="eventObj.event.summary"
             class="text-truncate my-auto ml-2 caption font-weight-bold">
@@ -77,13 +75,13 @@
             <date-format
               :value="eventObj.event.startDate"
               :format="timeFormat"
-              class="v-event-draggable ml-2" />
+              class="ml-2" />
             <strong
               class="mx-1">-</strong>
             <date-format
               :value="eventObj.event.endDate"
               :format="timeFormat"
-              class="v-event-draggable mr-2" />
+              class="mr-2" />
           </div>
         </div>
         <agenda-connector-remote-event-item
@@ -190,7 +188,9 @@ export default {
     if (this.$refs.calendar) {
       this.currentTimeTop = this.$refs.calendar.timeToY(this.nowTimeOptions);
       const event = Object.assign({}, this.event);
-      this.event.startDate = null;
+      if (!event.created && !event.added) {
+        this.event.startDate = null;
+      }
       this.scrollToEvent(event);
     }
     this.$root.$on('agenda-event-save', () => {
@@ -216,13 +216,6 @@ export default {
           dailyScrollElement.scrollTo(0, scrollY);
         }
       });
-    },
-    showEvent(nativeEvent) {
-      if (!nativeEvent) {
-        return;
-      }
-      nativeEvent.preventDefault();
-      nativeEvent.stopPropagation();
     },
     startTime(tms) {
       //refresh after assigning a startDate for the new event for the first time only


### PR DESCRIPTION
New UX: when we create an event from the `Schedule Button`, we should not see an event placed in agenda with `now date` as `startDate`. And also we should remove the popin and only let the user choose `start/end date` from `drag&drop` actions. Besides, 
 we disable the `create button` until a date is selected.