### PR TITLE
TASK-39714 Fix errors when displaying events with a deleted space (#196)

### DIFF
--- a/agenda-api/src/main/java/org/exoplatform/agenda/model/Calendar.java
+++ b/agenda-api/src/main/java/org/exoplatform/agenda/model/Calendar.java
@@ -29,6 +29,8 @@ public class Calendar implements Cloneable {
 
   private boolean    system;
 
+  private boolean    deleted;
+
   private String     title;
 
   private String     description;
@@ -41,7 +43,27 @@ public class Calendar implements Cloneable {
 
   private Permission acl;
 
+  public Calendar(long id,
+                  long ownerId,
+                  boolean system,
+                  String title,
+                  String description,
+                  String created,
+                  String updated,
+                  String color,
+                  Permission acl) {
+    this.id = id;
+    this.ownerId = ownerId;
+    this.system = system;
+    this.title = title;
+    this.description = description;
+    this.created = created;
+    this.updated = updated;
+    this.color = color;
+    this.acl = acl;
+  }
+
   public Calendar clone() { // NOSONAR
-    return new Calendar(id, ownerId, system, title, description, created, updated, color, acl);
+    return new Calendar(id, ownerId, system, deleted, title, description, created, updated, color, acl);
   }
 }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -29,6 +29,7 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.notification.LinkProviderUtils;
@@ -464,16 +465,18 @@ public class NotificationUtils {
     String ownerId = notification.getValueOwnerParameter(STORED_PARAMETER_EVENT_OWNER_ID);
     IdentityManager identityManager = ExoContainerContext.getService(IdentityManager.class);
     Identity identity = identityManager.getIdentity(ownerId);
-    if (identity != null) {
-      String avatarUrl = null;
+    String avatarUrl = null;
+    if (identity == null) {
+      avatarUrl = LinkProvider.SPACE_DEFAULT_AVATAR_URL;
+    } else {
       if (SpaceIdentityProvider.NAME.equals(identity.getProviderId())) {
         Space space = spaceService.getSpaceByPrettyName(identity.getRemoteId());
         avatarUrl = LinkProviderUtils.getSpaceAvatarUrl(space);
       } else {
         avatarUrl = LinkProviderUtils.getUserAvatarUrl(identity.getProfile());
       }
-      templateContext.put(TEMPLATE_VARIABLE_SUFFIX_IDENTITY_AVATAR, avatarUrl);
     }
+    templateContext.put(TEMPLATE_VARIABLE_SUFFIX_IDENTITY_AVATAR, avatarUrl);
   }
 
   private static final void setSpaceName(NotificationInfo notification, TemplateContext templateContext) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -297,7 +297,7 @@ public class Utils {
                                         long userIdentityId) {
     Identity requestedOwner = identityManager.getIdentity(String.valueOf(ownerId));
     if (requestedOwner == null) {
-      throw new IllegalStateException("Calendar owner with id " + ownerId + " wasn't found");
+      return false;
     }
     Identity userIdentity = identityManager.getIdentity(String.valueOf(userIdentityId));
     if (userIdentity == null) {
@@ -332,7 +332,7 @@ public class Utils {
                                           long userIdentityId) {
     Identity requestedOwner = identityManager.getIdentity(String.valueOf(ownerId));
     if (requestedOwner == null) {
-      throw new IllegalStateException("Calendar owner with id " + ownerId + " wasn't found");
+      return false;
     }
 
     Identity userIdentity = identityManager.getIdentity(String.valueOf(userIdentityId));

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaCalendarServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaCalendarServiceTest.java
@@ -110,6 +110,12 @@ public class AgendaCalendarServiceTest {
     long notExistingCalendarId = calendarId + 2;
     retrievedCalendar = agendaCalendarService.getCalendarById(notExistingCalendarId);
     assertNull("Should return null when trying to retrieve inexistant calendar", retrievedCalendar);
+
+    // 3. Test deleting a calendar
+    when(identityManager.getIdentity(eq(String.valueOf(calendarOwnerId)))).thenReturn(null);
+    retrievedCalendar = agendaCalendarService.getCalendarById(calendarId);
+    assertNotNull(retrievedCalendar);
+    assertTrue(retrievedCalendar.isDeleted());
   }
 
   @Test


### PR DESCRIPTION
When deleting a space, the calendar isn't deleted and thus the events remains accessible to user.
This PR will handle deleting a space by checking space identity presence.

(cherry picked from commit fd8feb81c57d3e1320931454d7d227d5a9f8f704)