### PR TITLE
TASK-40537 Fix deleting single occurrence event

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
@@ -229,6 +229,10 @@ public class AgendaEventReminderServiceImpl implements AgendaEventReminderServic
                                   long identityId) throws AgendaException {
     long eventId = event.getId();
     boolean isRecurrentEvent = event.getRecurrence() != null;
+    if (event.getStatus() != EventStatus.CONFIRMED) {
+      // Delete all reminders of user when event is not confirmed yet
+      reminders = null;
+    }
 
     List<EventReminder> savedReminders = getEventReminders(eventId, identityId);
     List<EventReminder> newReminders = reminders == null ? Collections.emptyList() : reminders;

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
@@ -20,8 +20,7 @@ import static org.junit.Assert.*;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.junit.Test;
 
@@ -61,6 +60,68 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
     eventReminders = agendaEventReminderService.getEventReminders(eventId, userIdentityId);
     assertNotNull(eventReminders);
     assertEquals(0, eventReminders.size());
+  }
+
+  @Test
+  public void testUpdateEventStatus() throws Exception { // NOSONAR
+    ZonedDateTime start = ZonedDateTime.now().withNano(0);
+
+    boolean allDay = false;
+    long userIdentityId = Long.parseLong(testuser1Identity.getId());
+
+    Event event = newEventInstance(start, start, allDay);
+    event = createEvent(event.clone(), userIdentityId, testuser5Identity);
+
+    long eventId = event.getId();
+    List<EventReminder> eventReminders = agendaEventReminderService.getEventReminders(eventId, userIdentityId);
+    assertNotNull(eventReminders);
+    assertEquals(1, eventReminders.size());
+
+    List<EventReminder> origEventReminders = new ArrayList<>(eventReminders);
+
+    List<EventAttendee> attendees = agendaEventAttendeeService.getEventAttendees(eventId);
+
+    event.setStatus(EventStatus.CANCELLED);
+    event = agendaEventService.updateEvent(event,
+                                           attendees,
+                                           Collections.emptyList(),
+                                           Collections.emptyList(),
+                                           origEventReminders,
+                                           null,
+                                           null,
+                                           false,
+                                           userIdentityId);
+    eventReminders = agendaEventReminderService.getEventReminders(eventId, userIdentityId);
+    assertNotNull(eventReminders);
+    assertEquals(0, eventReminders.size());
+
+    event.setStatus(EventStatus.TENTATIVE);
+    event = agendaEventService.updateEvent(event,
+                                           attendees,
+                                           Collections.emptyList(),
+                                           Collections.emptyList(),
+                                           origEventReminders,
+                                           null,
+                                           null,
+                                           false,
+                                           userIdentityId);
+    eventReminders = agendaEventReminderService.getEventReminders(eventId, userIdentityId);
+    assertNotNull(eventReminders);
+    assertEquals(0, eventReminders.size());
+
+    event.setStatus(EventStatus.CONFIRMED);
+    agendaEventService.updateEvent(event,
+                                   attendees,
+                                   Collections.emptyList(),
+                                   Collections.emptyList(),
+                                   origEventReminders,
+                                   null,
+                                   null,
+                                   false,
+                                   userIdentityId);
+    eventReminders = agendaEventReminderService.getEventReminders(eventId, userIdentityId);
+    assertNotNull(eventReminders);
+    assertEquals(1, eventReminders.size());
   }
 
   @Test
@@ -235,7 +296,7 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
     assertNotNull(savedUpcomingEventReminder);
     assertNotNull(savedUpcomingEventReminder.getDatetime());
 
-    exceptionalOccurrence = agendaEventService.saveEventExceptionalOccurrence(eventId, start.plusDays(4));
+    agendaEventService.saveEventExceptionalOccurrence(eventId, start.plusDays(4));
     assertNotNull(eventReminders);
     assertEquals(1, eventReminders.size());
     savedUpcomingEventReminder = eventReminders.get(0);


### PR DESCRIPTION
In MySQL, it seems that the Date '1970-01-01 00:00:00.0' is not supported, thus we delete completely the reminders when the status of the event is different from confirmed instead of storing them with a computed trigger date = 0