### PR TITLE
TASK-41130 Fix gamification points collection

### DIFF
--- a/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeService.java
+++ b/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeService.java
@@ -139,6 +139,22 @@ public interface AgendaEventAttendeeService {
                                                                 IllegalAccessException;
 
   /**
+   * @param eventId Technical identifier of {@link Event}
+   * @param identityId {@link Identity} technical identifier of user
+   * @param response User response of type {@link EventAttendeeResponse} to the
+   *          event. The value {@link EventAttendeeResponse#NEEDS_ACTION} isn't
+   *          allowed.
+   * @param broadcast whether broadcast event about this change or not
+   * @throws ObjectNotFoundException when event with provided identifier doesn't
+   *           exists
+   * @throws IllegalAccessException when user is not an invitee of the event
+   */
+  public void sendEventResponse(long eventId,
+                                long identityId,
+                                EventAttendeeResponse response,
+                                boolean broadcast) throws ObjectNotFoundException, IllegalAccessException;
+
+  /**
    * Checks whether the user is an attendee of the event or not
    * 
    * @param eventId Technical identifier of {@link Event}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaReplyOnSaveListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaReplyOnSaveListener.java
@@ -53,7 +53,9 @@ public class AgendaReplyOnSaveListener extends Listener<AgendaEventModification,
             for (EventAttendee eventAttendee : eventAttendees) {
               EventAttendeeResponse response = modifierId == eventAttendee.getIdentityId() ? EventAttendeeResponse.ACCEPTED
                                                                                            : EventAttendeeResponse.NEEDS_ACTION;
-              getAgendaEventAttendeeService().sendEventResponse(eventId, eventAttendee.getIdentityId(), response);
+              if (eventAttendee.getResponse() != response) {
+                getAgendaEventAttendeeService().sendEventResponse(eventId, eventAttendee.getIdentityId(), response, false);
+              }
             }
           }
           break;

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaVotesListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaVotesListener.java
@@ -25,7 +25,7 @@ public class AgendaVotesListener extends Listener<Long, Long> {
   public void onEvent(Event<Long, Long> event) throws Exception {
     long eventId = event.getSource();
     long identityId = event.getData();
-    getAttendeeService().sendEventResponse(eventId, identityId, EventAttendeeResponse.TENTATIVE);
+    getAttendeeService().sendEventResponse(eventId, identityId, EventAttendeeResponse.TENTATIVE, false);
   }
 
   private AgendaEventAttendeeService getAttendeeService() {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeServiceImpl.java
@@ -138,6 +138,17 @@ public class AgendaEventAttendeeServiceImpl implements AgendaEventAttendeeServic
   public void sendEventResponse(long eventId,
                                 long identityId,
                                 EventAttendeeResponse response) throws ObjectNotFoundException, IllegalAccessException {
+    sendEventResponse(eventId, identityId, response, true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void sendEventResponse(long eventId,
+                                long identityId,
+                                EventAttendeeResponse response,
+                                boolean broadcast) throws ObjectNotFoundException, IllegalAccessException {
     if (response == null) {
       throw new IllegalArgumentException("Attendee response is mandatory");
     }
@@ -154,7 +165,7 @@ public class AgendaEventAttendeeServiceImpl implements AgendaEventAttendeeServic
       throw new IllegalAccessException("User with identity id " + identityId + " isn't attendee of event with id " + eventId);
     }
 
-    saveEventAttendee(eventId, identityId, response, true);
+    saveEventAttendee(eventId, identityId, response, broadcast);
 
     // Apply modification on exceptional occurrences as well
     if (eventStorage.isRecurrentEvent(eventId)) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventDatePollServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventDatePollServiceImpl.java
@@ -57,8 +57,6 @@ public class AgendaEventDatePollServiceImpl implements AgendaEventDatePollServic
       createdDateOptions.add(createdDateOption);
     }
 
-    Utils.broadcastEvent(listenerService, Utils.POST_CREATE_AGENDA_EVENT_POLL, eventId, userIdentityId);
-
     return createdDateOptions;
   }
 
@@ -103,7 +101,6 @@ public class AgendaEventDatePollServiceImpl implements AgendaEventDatePollServic
       datePollStorage.deleteDateOption(eventDateOption);
     }
 
-    Utils.broadcastEvent(listenerService, Utils.POST_UPDATE_AGENDA_EVENT_POLL, eventId, dateOptions);
     return dateOptionModifications;
   }
 

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
@@ -348,7 +348,13 @@ public class AgendaEventServiceImpl implements AgendaEventService {
                                          eventModifications);
     }
 
-    Utils.broadcastEvent(listenerService, Utils.POST_CREATE_AGENDA_EVENT_EVENT, eventModifications, null);
+    if (createdEvent.getStatus() == EventStatus.TENTATIVE) {
+      Utils.broadcastEvent(listenerService, Utils.POST_CREATE_AGENDA_EVENT_POLL, eventModifications, null);
+    } else if (createdEvent.getStatus() == EventStatus.CONFIRMED) {
+      Utils.broadcastEvent(listenerService, Utils.POST_CREATE_AGENDA_EVENT_EVENT, eventModifications, null);
+    } else if (createdEvent.getStatus() == EventStatus.CANCELLED) {
+      Utils.broadcastEvent(listenerService, Utils.POST_DELETE_AGENDA_EVENT_EVENT, eventModifications, null);
+    }
     return createdEvent;
   }
 

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -62,8 +62,6 @@ public class Utils {
 
   public static final String            POST_CREATE_AGENDA_EVENT_POLL  = "exo.agenda.event.poll.created";
 
-  public static final String            POST_UPDATE_AGENDA_EVENT_POLL  = "exo.agenda.event.poll.updated";
-
   public static final String            POST_VOTES_AGENDA_EVENT_POLL   = "exo.agenda.event.poll.voted.all";
 
   public static final String            POST_VOTE_AGENDA_EVENT_POLL    = "exo.agenda.event.poll.voted";

--- a/agenda-services/src/main/resources/conf/portal/configuration.xml
+++ b/agenda-services/src/main/resources/conf/portal/configuration.xml
@@ -274,6 +274,11 @@
       <type>org.exoplatform.agenda.listener.AgendaReplyOnSaveListener</type>
     </component-plugin>
     <component-plugin>
+      <name>exo.agenda.event.poll.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.agenda.listener.AgendaReplyOnSaveListener</type>
+    </component-plugin>
+    <component-plugin>
       <name>exo.agenda.event.updated</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.agenda.listener.AgendaReplyOnSaveListener</type>

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventDatePollServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventDatePollServiceTest.java
@@ -72,6 +72,9 @@ public class AgendaEventDatePollServiceTest extends BaseAgendaEventTest {
     assertEquals(start.withZoneSameInstant(ZoneOffset.UTC), createdEvent.getStart());
     assertEquals(end.withZoneSameInstant(ZoneOffset.UTC), createdEvent.getEnd());
     assertEquals(EventStatus.CONFIRMED, createdEvent.getStatus());
+    assertNotNull(eventCreationReference.get());
+    assertEquals(createdEvent.getId(), eventCreationReference.get().getEventId());
+    assertNull(eventPollCreationReference.get());
 
     List<EventDateOption> dateOptions = agendaEventDatePollService.getEventDateOptions(createdEvent.getId(), ZoneOffset.UTC);
     assertTrue(dateOptions == null || dateOptions.isEmpty());
@@ -149,6 +152,9 @@ public class AgendaEventDatePollServiceTest extends BaseAgendaEventTest {
     assertEquals(dateOption1.getStart().withZoneSameInstant(ZoneOffset.UTC), createdEvent.getStart());
     assertEquals(dateOption2.getEnd().withZoneSameInstant(ZoneOffset.UTC), createdEvent.getEnd());
     assertEquals(EventStatus.TENTATIVE, createdEvent.getStatus());
+    assertNotNull(eventPollCreationReference.get());
+    assertEquals(createdEvent.getId(), eventPollCreationReference.get().getEventId());
+    assertNull(eventCreationReference.get());
 
     List<EventAttendee> eventAttendees = agendaEventAttendeeService.getEventAttendees(createdEvent.getId());
     assertNotNull(eventAttendees);

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
@@ -44,6 +44,8 @@ public abstract class BaseAgendaEventTest {
 
   protected static AtomicReference<AgendaEventModification> eventCreationReference;
 
+  protected static AtomicReference<AgendaEventModification> eventPollCreationReference;
+
   protected static AtomicReference<AgendaEventModification> eventDeletionReference;
 
   protected static AtomicReference<AgendaEventModification> eventUpdateReference;
@@ -132,8 +134,16 @@ public abstract class BaseAgendaEventTest {
         }
       };
       listenerService.addListener(Utils.POST_CREATE_AGENDA_EVENT_EVENT, creationListener);
-    } else {
-      eventCreationReference.set(null);
+    }
+    if (eventPollCreationReference == null) {
+      eventPollCreationReference = new AtomicReference<>();// NOSONAR
+      Listener<AgendaEventModification, Object> pollCreationListener = new Listener<AgendaEventModification, Object>() {
+        @Override
+        public void onEvent(org.exoplatform.services.listener.Event<AgendaEventModification, Object> event) throws Exception {
+          eventPollCreationReference.set(event.getSource());
+        }
+      };
+      listenerService.addListener(Utils.POST_CREATE_AGENDA_EVENT_POLL, pollCreationListener);
     }
     if (eventUpdateReference == null) {
       eventUpdateReference = new AtomicReference<>();// NOSONAR
@@ -144,8 +154,6 @@ public abstract class BaseAgendaEventTest {
         }
       };
       listenerService.addListener(Utils.POST_UPDATE_AGENDA_EVENT_EVENT, updateListener);
-    } else {
-      eventUpdateReference.set(null);
     }
     if (eventDeletionReference == null) {
       eventDeletionReference = new AtomicReference<>();// NOSONAR
@@ -156,8 +164,6 @@ public abstract class BaseAgendaEventTest {
         }
       };
       listenerService.addListener(Utils.POST_DELETE_AGENDA_EVENT_EVENT, deletionListener);
-    } else {
-      eventDeletionReference.set(null);
     }
   }
 
@@ -235,6 +241,11 @@ public abstract class BaseAgendaEventTest {
       agendaCalendarService.deleteCalendarById(calendar.getId());
       calendar = null;
     }
+
+    eventCreationReference.set(null);
+    eventPollCreationReference.set(null);
+    eventUpdateReference.set(null);
+    eventDeletionReference.set(null);
   }
 
   @SuppressWarnings("unchecked")

--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/listeners-configuration.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/listeners-configuration.xml
@@ -11,6 +11,11 @@
       <type>org.exoplatform.agenda.listener.AgendaESListener</type>
     </component-plugin>
     <component-plugin>
+      <name>exo.agenda.event.poll.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.agenda.listener.AgendaESListener</type>
+    </component-plugin>
+    <component-plugin>
       <name>exo.agenda.event.updated</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.agenda.listener.AgendaESListener</type>


### PR DESCRIPTION
When creating an event, even when creator default response is ACCEPTED, only gamification points for event creation should be added.
When a date poll is created a specific listener has to be triggered to get specific gamification points.