### PR TITLE
TASK-40943 Fix changing Event dates in first step

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
@@ -206,6 +206,20 @@ export default {
         this.$refs.calendarOwner.resetCustomValidity();
       }
     },
+    updateEventDates() {
+      this.event.startDate = new Date(this.eventDateOption.startDate);
+      this.event.endDate = new Date(this.eventDateOption.endDate);
+
+      this.event.start = this.$agendaUtils.toRFC3339(this.event.startDate);
+      this.event.end = this.$agendaUtils.toRFC3339(this.event.endDate);
+
+      if (this.event.dateOptions && this.event.dateOptions.length === 1) {
+        this.event.dateOptions[0].startDate = new Date(this.event.startDate);
+        this.event.dateOptions[0].endDate = new Date(this.event.endDate);
+        this.event.dateOptions[0].start = this.event.start;
+        this.event.dateOptions[0].end = this.event.end;
+      }
+    },
     validateForm() {
       this.resetCustomValidity();
       this.$refs.calendarOwner.validateForm();


### PR DESCRIPTION
When changing event dates in first step of Event form, it doesn't take effect in second step when editing an event.
This fix will make sure to update startDate and endDate on dateOption and event at the same time