### PR TITLE
Fix HSQLDB In-Memory Unnamed Contraint Dropping

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/liquibase/DropHSQLDBUniqueConstraint.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/liquibase/DropHSQLDBUniqueConstraint.java
@@ -52,6 +52,11 @@ public class DropHSQLDBUniqueConstraint implements CustomTaskChange {
       CallableStatement dropConstraintQuery = connection.prepareCall("ALTER TABLE " + tableName + " DROP CONSTRAINT "
           + constraintName);
       dropConstraintQuery.execute();
+      // This will close the database and write .log file into .script
+      // to avoid this problem:
+      // https://stackoverflow.com/questions/32266213/hsqldb-unable-to-drop-foreign-key-constraint-object-not-found
+      CallableStatement hsqldbCheckpointQuery = connection.prepareCall("CHECKPOINT");
+      hsqldbCheckpointQuery.execute();
       connection.commit();
     } catch (Exception e) {
       throw new CustomChangeException("Error dropping constraint of table " +

--- a/agenda-services/src/main/resources/conf/configuration.xml
+++ b/agenda-services/src/main/resources/conf/configuration.xml
@@ -15,4 +15,20 @@
     </init-params>
   </component>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>AgendaRDBMSChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of Agenda RDBMS</description>
+          <value>db/changelog/agenda-rdbms.db.changelog.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>

--- a/agenda-services/src/main/resources/conf/portal/configuration.xml
+++ b/agenda-services/src/main/resources/conf/portal/configuration.xml
@@ -195,22 +195,6 @@
   </component>
 
   <external-component-plugins>
-    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
-    <component-plugin>
-      <name>AgendaRDBMSChangeLogsPlugin</name>
-      <set-method>addChangeLogsPlugin</set-method>
-      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
-      <init-params>
-        <values-param>
-          <name>changelogs</name>
-          <description>Change logs of Agenda RDBMS</description>
-          <value>db/changelog/agenda-rdbms.db.changelog.xml</value>
-        </values-param>
-      </init-params>
-    </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
     <target-component>org.exoplatform.social.core.space.spi.SpaceService</target-component>
     <component-plugin>
       <name>AgendaSpaceApplicationListener</name>

--- a/agenda-services/src/test/resources/conf/exo.agenda.service-configuration.xml
+++ b/agenda-services/src/test/resources/conf/exo.agenda.service-configuration.xml
@@ -8,6 +8,22 @@
   </component>
 
   <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>AgendaRDBMSChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of Agenda RDBMS</description>
+          <value>db/changelog/agenda-rdbms.db.changelog.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
     <target-component>org.exoplatform.commons.api.notification.service.setting.PluginSettingService</target-component>
     <component-plugin>
       <name>notification.groups</name>


### PR DESCRIPTION
With HSQLDB In-Memory, the nameless constraints will receive an auto generated constraint name each starup. In addition to this, the In-Memory DB will writes changes made on DB in a log file that will be added to DB script file only when a CHECKPOINT is made or a restart of the server.
Knowing this, prior to this change, when the Agenda Liquibase Custom Change 'DropHSQLDBUniqueConstraint' will add a new 'DROP CONSTRAINT' query for a nameless CONSTRAINT, the log file will trace it but not add it in script file of DB. The next server startup, when the DB starts, it will attempt to re-execute the log file and apply changes on script file, but the error 'user lacks privilege or object not found: SYS_CT_XXXXX' is raised because the nameless constraint had received a new name. Consequently, the next LIQUIBASE statements will not be executed and it will remain locked.
This fix, will ensure to make a DB checkpoint to write modification, just after dropping the nameless constraint. In addition, the Agenda liquibase changelog declaration has been moved to RootContainer in order to not make a checkpoint (that closes opened connections) in PortalContainer where we can have parallel threads that are working on DB.