### PR TITLE
Task-42704: Enable create event for redactional space manager (space with redactors)

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -348,11 +348,16 @@ public class Utils {
     } else if (StringUtils.equals(SpaceIdentityProvider.NAME, requestedOwner.getProviderId())) {
       boolean superManager = spaceService.isSuperManager(userIdentity.getRemoteId());
       Space space = spaceService.getSpaceByPrettyName(requestedOwner.getRemoteId());
+      if (spaceService.isSuperManager(userIdentity.getRemoteId())) {
+        return true;
+      } else if (space == null) {
+        return false;
+      }
       boolean isManager = space != null && spaceService.isManager(space, userIdentity.getRemoteId());
       boolean isMember = space != null && spaceService.isMember(space, userIdentity.getRemoteId());
       boolean isRedactor = space != null && spaceService.isRedactor(space, userIdentity.getRemoteId());
       boolean spaceHasARedactor = space != null && space.getRedactors() != null && space.getRedactors().length > 0;
-      return (!spaceHasARedactor || isRedactor || isManager) && (superManager || isMember);
+      return isMember && (!spaceHasARedactor || isRedactor || isManager);
     } else {
       return false;
     }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -348,10 +348,11 @@ public class Utils {
     } else if (StringUtils.equals(SpaceIdentityProvider.NAME, requestedOwner.getProviderId())) {
       boolean superManager = spaceService.isSuperManager(userIdentity.getRemoteId());
       Space space = spaceService.getSpaceByPrettyName(requestedOwner.getRemoteId());
+      boolean isManager = space != null && spaceService.isManager(space, userIdentity.getRemoteId());
       boolean isMember = space != null && spaceService.isMember(space, userIdentity.getRemoteId());
       boolean isRedactor = space != null && spaceService.isRedactor(space, userIdentity.getRemoteId());
       boolean spaceHasARedactor = space != null && space.getRedactors() != null && space.getRedactors().length > 0;
-      return (!spaceHasARedactor || isRedactor) && (superManager || isMember);
+      return (!spaceHasARedactor || isRedactor || isManager) && (superManager || isMember);
     } else {
       return false;
     }

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -424,9 +424,10 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
     ZonedDateTime start = getDate().withNano(0);
 
     boolean allDay = true;
-
+    spaceService.addRedactor(space, testuser1Identity.getRemoteId());
+    spaceService.setManager(space, testuser2Identity.getRemoteId(), true);
     Event event = newEventInstance(start, start, allDay);
-    event.setCalendarId(spaceCalendar1.getId());
+    event.setCalendarId(spaceCalendar.getId());
     Event createdEvent = createEvent(event.clone(),
                                      Long.parseLong(testuser2Identity.getId()),
                                      testuser3Identity);

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -420,6 +420,28 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
   }
 
   @Test
+  public void testCreateEvent_InSpace_AsManager() throws Exception { // NOSONAR
+    ZonedDateTime start = getDate().withNano(0);
+
+    boolean allDay = true;
+
+    Event event = newEventInstance(start, start, allDay);
+    event.setCalendarId(spaceCalendar1.getId());
+    Event createdEvent = createEvent(event.clone(),
+                                     Long.parseLong(testuser2Identity.getId()),
+                                     testuser3Identity);
+
+    assertNotNull(createdEvent);
+    assertTrue(createdEvent.getId() > 0);
+    AgendaEventModification eventModification = eventCreationReference.get();
+    assertNotNull(eventModification);
+    assertTrue(eventModification.hasModification(AgendaEventModificationType.ADDED));
+    assertEquals("Modification types are more than expected : " + eventModification.getModificationTypes(),
+                 1,
+                 eventModification.getModificationTypes().size());
+  }
+
+  @Test
   public void testGetEventById() throws Exception { // NOSONAR
     ZonedDateTime start = getDate().withNano(0);
 

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
@@ -80,15 +80,9 @@ public abstract class BaseAgendaEventTest {
 
   protected Calendar                                        spaceCalendar;
 
-  protected Calendar                                        spaceCalendar1;
-
   protected Space                                           space;
 
-  protected Space                                           space1;
-
   protected Identity                                        spaceIdentity;
-
-  protected Identity                                        spaceIdentity1;
 
   protected Identity                                        testuser1Identity;
 
@@ -231,25 +225,6 @@ public abstract class BaseAgendaEventTest {
                                                                                       "Client API Key",
                                                                                       true));
     }
-
-    String displayName1 = "testSpaceAgenda1" + RandomUtils.nextInt();
-    space1 = createSpace(displayName1,
-                         testuser1Identity.getRemoteId(),
-                         testuser2Identity.getRemoteId(),
-                         testuser3Identity.getRemoteId());
-    spaceIdentity1 = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space1.getPrettyName());
-    spaceCalendar1 = agendaCalendarService.createCalendar(new Calendar(0,
-                                                                      Long.parseLong(spaceIdentity1.getId()),
-                                                                      false,
-                                                                      null,
-                                                                      CALENDAR_DESCRIPTION,
-                                                                      null,
-                                                                      null,
-                                                                      CALENDAR_COLOR,
-                                                                      null));
-    space1 = spaceService.getSpaceByDisplayName(displayName1);
-    spaceService.addRedactor(space1, testuser3Identity.getRemoteId());
-    spaceService.setManager(space1, testuser2Identity.getRemoteId(), true);
   }
 
   protected void purgeData() throws ObjectNotFoundException {
@@ -260,10 +235,6 @@ public abstract class BaseAgendaEventTest {
     if (calendar != null) {
       agendaCalendarService.deleteCalendarById(calendar.getId());
       calendar = null;
-    }
-    if (spaceCalendar1 != null) {
-      agendaCalendarService.deleteCalendarById(spaceCalendar1.getId());
-      spaceCalendar1 = null;
     }
 
     eventCreationReference.set(null);

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
@@ -80,9 +80,15 @@ public abstract class BaseAgendaEventTest {
 
   protected Calendar                                        spaceCalendar;
 
+  protected Calendar                                        spaceCalendar1;
+
   protected Space                                           space;
 
+  protected Space                                           space1;
+
   protected Identity                                        spaceIdentity;
+
+  protected Identity                                        spaceIdentity1;
 
   protected Identity                                        testuser1Identity;
 
@@ -225,6 +231,25 @@ public abstract class BaseAgendaEventTest {
                                                                                       "Client API Key",
                                                                                       true));
     }
+
+    String displayName1 = "testSpaceAgenda1" + RandomUtils.nextInt();
+    space1 = createSpace(displayName1,
+                         testuser1Identity.getRemoteId(),
+                         testuser2Identity.getRemoteId(),
+                         testuser3Identity.getRemoteId());
+    spaceIdentity1 = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space1.getPrettyName());
+    spaceCalendar1 = agendaCalendarService.createCalendar(new Calendar(0,
+                                                                      Long.parseLong(spaceIdentity1.getId()),
+                                                                      false,
+                                                                      null,
+                                                                      CALENDAR_DESCRIPTION,
+                                                                      null,
+                                                                      null,
+                                                                      CALENDAR_COLOR,
+                                                                      null));
+    space1 = spaceService.getSpaceByDisplayName(displayName1);
+    spaceService.addRedactor(space1, testuser3Identity.getRemoteId());
+    spaceService.setManager(space1, testuser2Identity.getRemoteId(), true);
   }
 
   protected void purgeData() throws ObjectNotFoundException {
@@ -235,6 +260,10 @@ public abstract class BaseAgendaEventTest {
     if (calendar != null) {
       agendaCalendarService.deleteCalendarById(calendar.getId());
       calendar = null;
+    }
+    if (spaceCalendar1 != null) {
+      agendaCalendarService.deleteCalendarById(spaceCalendar1.getId());
+      spaceCalendar1 = null;
     }
 
     eventCreationReference.set(null);


### PR DESCRIPTION
**Current behavior:** When adding at least a redactor for a space, the space manager or a super user or a space admin can no more create event.
**New Behavior:** When adding at least a redactor for a space, the space manager or a super user or a space admin can create events