### PR TITLE
Task-42425: When adding event, allow displaying redactional spaces for super admin, super spaces manager and space manager 

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormCalendarOwner.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormCalendarOwner.vue
@@ -10,6 +10,7 @@
     class="user-suggester calendarOwnerAutocomplete"
     include-spaces
     only-redactor
+    only-manager
     required />
 </template>
 


### PR DESCRIPTION
**Current behavior:** When adding event from snapshot events widget,  the spaces suggestor will not display:
- Redactional spaces (with at least one redactor) on which I'm manager or when I'm a super spaces manager or super admin

**New behavior:** When adding event from snapshot events widget,  the spaces suggestor will display:
- Redactional spaces (with at least one redactor) on which I'm manager or when I'm a super spaces manager or super admin