### PR TITLE
TASK-44787 : Rework JPQL to be compliant with PostgreSQL

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/entity/EventEntity.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/entity/EventEntity.java
@@ -81,7 +81,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
       ),
       @NamedQuery(
           name = "AgendaEvent.getPendingEventIds",
-          query = "SELECT DISTINCT(ev.id), ev.createdDate, ev.updatedDate FROM AgendaEvent ev"
+          query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
               + " WHERE ev.status = :status"
               + " AND (ev.endDate IS NULL OR ev.endDate > :date)"
@@ -97,13 +97,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
               + "         AND att2.identityId = :userIdentityId"
               + "         AND att2.response != :response"
               + " )"
-              + " ORDER BY "
-              + "   CASE "
-              + "     WHEN ev.updatedDate IS NULL"
-              + "       THEN ev.createdDate"
-              + "     ELSE ev.updatedDate"
-              + "   END"
-              + " DESC"
+              + " ORDER BY ev.updatedDate DESC"
       ),
       @NamedQuery(
           name = "AgendaEvent.countPendingEvents",
@@ -147,7 +141,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
       ),
       @NamedQuery(
           name = "AgendaEvent.getPendingEventIdsByOwnerIds",
-          query = "SELECT DISTINCT(ev.id), ev.createdDate, ev.updatedDate FROM AgendaEvent ev"
+          query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
               + " INNER JOIN ev.calendar cal"
               + " WHERE ev.status = :status"
@@ -165,44 +159,26 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
               + "         AND att2.identityId = :userIdentityId"
               + "         AND att2.response != :response"
               + " )"
-              + " ORDER BY "
-              + "   CASE "
-              + "     WHEN ev.updatedDate IS NULL"
-              + "       THEN ev.createdDate"
-              + "     ELSE ev.updatedDate"
-              + "   END"
-              + " DESC"
+              + " ORDER BY ev.updatedDate DESC"
       ),
       @NamedQuery(
           name = "AgendaEvent.getPendingDatePollIds",
-          query = "SELECT DISTINCT(ev.id), ev.createdDate, ev.updatedDate FROM AgendaEvent ev"
+          query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
               + " WHERE ev.status = :status"
               + " AND (ev.endDate IS NULL OR ev.endDate > :date OR ev.creatorId = :userIdentityId)"
               + " AND att.identityId IN (:attendeeIds)"
-              + " ORDER BY "
-              + "   CASE "
-              + "     WHEN ev.updatedDate IS NULL"
-              + "       THEN ev.createdDate"
-              + "     ELSE ev.updatedDate"
-              + "   END"
-              + " DESC"
+              + " ORDER BY ev.updatedDate DESC"
       ),
       @NamedQuery(
           name = "AgendaEvent.getDatePollIdsByDates",
-          query = "SELECT DISTINCT(ev.id), ev.createdDate, ev.updatedDate FROM AgendaEvent ev"
+          query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
               + " WHERE ev.status = :status"
               + " AND (ev.endDate IS NULL OR ev.endDate > :start)"
               + " AND (ev.startDate < :end)"
               + " AND att.identityId IN (:attendeeIds)"
-              + " ORDER BY "
-              + "   CASE "
-              + "     WHEN ev.updatedDate IS NULL"
-              + "       THEN ev.createdDate"
-              + "     ELSE ev.updatedDate"
-              + "   END"
-              + " DESC"
+              + " ORDER BY ev.updatedDate DESC"
       ),
       @NamedQuery(
           name = "AgendaEvent.countPendingDatePoll",
@@ -214,7 +190,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
       ),
       @NamedQuery(
           name = "AgendaEvent.getDatePollIdsByOwnerIdsAndDates",
-          query = "SELECT DISTINCT(ev.id), ev.createdDate, ev.updatedDate FROM AgendaEvent ev"
+          query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
               + " INNER JOIN ev.calendar cal"
               + " WHERE ev.status = :status"
@@ -222,30 +198,18 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
               + " AND (ev.startDate < :end)"
               + " AND att.identityId IN (:attendeeIds)"
               + " AND cal.ownerId IN (:ownerIds)"
-              + " ORDER BY "
-              + "   CASE "
-              + "     WHEN ev.updatedDate IS NULL"
-              + "       THEN ev.createdDate"
-              + "     ELSE ev.updatedDate"
-              + "   END"
-              + " DESC"
+              + " ORDER BY ev.updatedDate DESC"
       ),
       @NamedQuery(
           name = "AgendaEvent.getPendingDatePollIdsByOwnerIds",
-          query = "SELECT DISTINCT(ev.id), ev.createdDate, ev.updatedDate FROM AgendaEvent ev"
+          query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
               + " INNER JOIN ev.calendar cal"
               + " WHERE ev.status = :status"
               + " AND (ev.endDate IS NULL OR ev.endDate > :date OR ev.creatorId = :userIdentityId)"
               + " AND att.identityId IN (:attendeeIds)"
               + " AND cal.ownerId IN (:ownerIds)"
-              + " ORDER BY "
-              + "   CASE "
-              + "     WHEN ev.updatedDate IS NULL"
-              + "       THEN ev.createdDate"
-              + "     ELSE ev.updatedDate"
-              + "   END"
-              + " DESC"
+              + " ORDER BY ev.updatedDate DESC"
       ),
       @NamedQuery(
           name = "AgendaEvent.countPendingDatePollByOwnerIds",

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/EntityMapper.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/EntityMapper.java
@@ -138,13 +138,19 @@ public class EntityMapper {
 
     ZoneId eventZoneId = eventEntity.getTimeZoneId() == null ? ZoneOffset.UTC : ZoneId.of(eventEntity.getTimeZoneId());
 
+    ZonedDateTime createdDate = AgendaDateUtils.fromDate(eventEntity.getCreatedDate());
+    ZonedDateTime updatedDate = null;
+    if (eventEntity.getModifierId() > 0) {
+      // Set updatedDate = null when no update was made on Event
+      updatedDate = AgendaDateUtils.fromDate(eventEntity.getUpdatedDate());
+    }
     return new Event(eventEntity.getId(),
                      parentId,
                      eventEntity.getCalendar().getId(),
                      eventEntity.getCreatorId(),
                      eventEntity.getModifierId(),
-                     AgendaDateUtils.fromDate(eventEntity.getCreatedDate()),
-                     AgendaDateUtils.fromDate(eventEntity.getUpdatedDate()),
+                     createdDate,
+                     updatedDate,
                      eventEntity.getSummary(),
                      eventEntity.getDescription(),
                      eventEntity.getLocation(),
@@ -174,7 +180,6 @@ public class EntityMapper {
     eventEntity.setAllDay(event.isAllDay());
     eventEntity.setAvailability(event.getAvailability());
     eventEntity.setColor(event.getColor());
-    eventEntity.setCreatedDate(AgendaDateUtils.toDate(event.getCreated()));
     eventEntity.setCreatorId(event.getCreatorId());
     eventEntity.setModifierId(event.getModifierId());
     eventEntity.setDescription(event.getDescription());
@@ -183,7 +188,14 @@ public class EntityMapper {
     eventEntity.setOccurrencePeriodChanged(event.getOccurrence() != null && event.getOccurrence().isDatesModified());
     eventEntity.setStatus(event.getStatus());
     eventEntity.setSummary(event.getSummary());
-    eventEntity.setUpdatedDate(AgendaDateUtils.toDate(event.getUpdated()));
+    // Add createdDate = updatedDate to be able to sort on it in DB queries
+    Date createdDate = AgendaDateUtils.toDate(event.getCreated());
+    eventEntity.setCreatedDate(createdDate);
+    if (event.getModifierId() <= 0) {
+      eventEntity.setUpdatedDate(createdDate);
+    } else {
+      eventEntity.setUpdatedDate(AgendaDateUtils.toDate(event.getUpdated()));
+    }
     eventEntity.setAllowAttendeeToInvite(event.isAllowAttendeeToInvite());
     eventEntity.setAllowAttendeeToUpdate(event.isAllowAttendeeToUpdate());
     eventEntity.setTimeZoneId(eventZoneId.getId());


### PR DESCRIPTION
Using CASE statement in ORDER BY need to use the same CASE statement in SELECTed fields to be compliant with PostgreSQL. Thus to fix this and improve JPQL performances, the field updatedDate is used in ORDER BY statement without CASE keyword. To do this, the entity must have always an updatedDate value that can be equal to createdDate field when the event wasn't modified yet. In storage layer, when the updatedDate = createdDate, to not change the previous behavior, the updatedDate will remain null when the event isn't updated