### PR TITLE
MAINT-48371: Fix agenda event poll indexing on creation event

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaESListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaESListener.java
@@ -48,6 +48,8 @@ public class AgendaESListener extends Listener<AgendaEventModification, Object> 
           reindexAgendaEvent(eventId, "update agenda event");
         } else if (Utils.POST_DELETE_AGENDA_EVENT_EVENT.equals(event.getEventName())) {
           unindexAgendaEvent(eventId, "delete agenda event");
+        } else if (Utils.POST_CREATE_AGENDA_EVENT_POLL.equals(event.getEventName())) {
+          reindexAgendaEvent(eventId, "create agenda event poll");
         }
       }
     } finally {


### PR DESCRIPTION
**ISSUE**: When Creating an agenda event poll the indexing service wasn't indexing the event because it wasn't called on event poll creation.
**FIX**: Add the indexing service on event poll creation case.