### PR TITLE
TASK-49084 Fix Event Dates with TimeZone using DST Saving in recurrent event

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
@@ -442,9 +442,12 @@ public class AgendaEventServiceImpl implements AgendaEventService {
                              .withMonth(occurrenceStartTime.getMonthValue())
                              .withDayOfMonth(occurrenceStartTime.getDayOfMonth());
     } else {
-      occurrenceStart = start.withYear(occurrenceId.getYear())
-                             .withMonth(occurrenceId.getMonthValue())
-                             .withDayOfMonth(occurrenceId.getDayOfMonth());
+      ZonedDateTime startStartTime = start.withZoneSameInstant(parentEvent.getTimeZoneId());
+      occurrenceStart = startStartTime.withYear(occurrenceId.getYear())
+                                      .withMonth(occurrenceId.getMonthValue())
+                                      .withDayOfMonth(occurrenceId.getDayOfMonth())
+                                      .withHour(startStartTime.getHour())
+                                      .withMinute(startStartTime.getMinute());
     }
     ZonedDateTime occurrenceEnd = occurrenceStart.plusSeconds(diffInSeconds);
     exceptionalEvent.setStart(occurrenceStart);

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -787,6 +787,54 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
   }
 
   @Test
+  public void testSaveEventExceptionalOccurrenceWithDST() throws Exception { // NOSONAR
+    ZoneId dstTimeZone = ZoneId.of("Europe/Paris");
+    ZonedDateTime start = ZonedDateTime.of(2021, 9, 15, 10, 0, 0, 0, dstTimeZone);
+    Event event = newEventInstance(start, start.plusHours(1), false);
+    event.setTimeZoneId(dstTimeZone);
+    EventRecurrence recurrence = new EventRecurrence(0,
+                                                     null,
+                                                     0,
+                                                     EventRecurrenceType.WEEKLY,
+                                                     EventRecurrenceFrequency.WEEKLY,
+                                                     1,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null);
+    event.setRecurrence(recurrence);
+
+    event = createEvent(event, Long.parseLong(testuser1Identity.getId()), testuser1Identity, testuser2Identity);
+
+    ZonedDateTime periodStart = ZonedDateTime.of(2021, 12, 3, 0, 0, 0, 0, dstTimeZone);
+    List<Event> eventOccurrencesInPeriod = agendaEventService.getEventOccurrencesInPeriod(event, periodStart, periodStart.plusWeeks(1), dstTimeZone, 0);
+    assertNotNull(eventOccurrencesInPeriod);
+    assertEquals(1, eventOccurrencesInPeriod.size());
+    Event occurrence = eventOccurrencesInPeriod.get(0);
+    assertNotNull(occurrence);
+    assertNotNull(occurrence.getOccurrence());
+
+    Event exceptionalOccurrence = agendaEventService.saveEventExceptionalOccurrence(event.getId(), occurrence.getOccurrence().getId());
+    ZonedDateTime exceptionalEventStart = exceptionalOccurrence.getStart().withZoneSameInstant(dstTimeZone);
+
+    assertNotNull(exceptionalOccurrence);
+    assertNotNull(exceptionalOccurrence.getOccurrence());
+    assertEquals(LocalDate.of(2021, 12, 8),
+                 exceptionalEventStart.toLocalDate());
+    assertEquals(start.getHour(),
+                 exceptionalEventStart.getHour());
+    assertEquals(start.getMinute(),
+                 exceptionalEventStart.getMinute());
+  }
+
+  @Test
   public void testGetParentRecurrentEvents() throws Exception { // NOSONAR
     ZonedDateTime start = getDate().withNano(0);
 


### PR DESCRIPTION
Prior to this change, saving an exceptional event created before DST saving switch, changes the start and end time of the event. This fix will ensure to preserve the same time as the original Parent Recurring event.