### PR TITLE
Fix Agenda Settings Icon display

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaHeader.vue
@@ -41,7 +41,7 @@
           :title="$t('agenda.settings.drawer.title')"
           class="d-none d-sm-inline text-header-title"
           @click="$root.$emit('user-settings-agenda-drawer-open')">
-          <v-icon>mdi-settings</v-icon>
+          <v-icon>mdi-cog</v-icon>
         </v-btn>
       </v-col>
     </v-row>


### PR DESCRIPTION
Prior to this change, the agenda settings icon isn't displayed. This modification ensures to use the correct code for settings icon.