### PR TITLE
Task-48693: Agenda event planned jitsi call isn't launched when space name is edited afterwards (#349)

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
@@ -268,7 +268,7 @@ export default {
     saveEvent() {
       this.event.start = this.event.startDate && this.$agendaUtils.toRFC3339(this.event.startDate) || this.$agendaUtils.toRFC3339(new Date());
       this.event.end = this.event.endDate && this.$agendaUtils.toRFC3339(this.event.endDate) || this.$agendaUtils.toRFC3339(new Date());
-
+      this.event.calendar.owner.id = this.selectedCalendar.owner.id;
       this.$root.$emit('agenda-event-save', this.event);
     },
     nextStep() {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -271,6 +271,7 @@ export default {
 
       this.event.start = this.$agendaUtils.toRFC3339(this.event.startDate);
       this.event.end = this.$agendaUtils.toRFC3339(this.event.endDate);
+      this.event.calendar.owner.id = this.currentCalendar.owner.id;
 
       delete this.event.startDate;
       delete this.event.endDate;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
@@ -62,7 +62,7 @@ function createConference(event, conference) {
       const endDate = event.endDate && new Date(event.endDate) || event.recurrence && event.recurrence.until && new Date(event.recurrence.until) || null;
       return global.webConferencing.addCall({
         title: event.title,
-        owner: event.calendar.owner.remoteId,
+        owner: event.calendar.owner.id,
         ownerType: 'space_event',
         provider: conference.type,
         participants: participants && participants.join(';') || null,
@@ -96,7 +96,7 @@ function updateConference(event, conference) {
       const endDate = event.endDate && new Date(event.endDate) || event.recurrence && event.recurrence.until && new Date(event.recurrence.until) || null;
       return global.webConferencing.updateCall(callId, {
         title: event.title,
-        owner: event.calendar.owner.remoteId,
+        owner: event.calendar.owner.id,
         ownerType: 'space_event',
         provider: conference.type,
         participants: participants && participants.join(';') || null,


### PR DESCRIPTION
Prior to this fix, we couldn't lunch a scheduled jitsi call in a space event after renaming the space.
To fix this problem we need to use the space identity id of the space as ownerId instead of the spacePrettyName