### PR TITLE
MAINT-50873: Fix Jitsi getting call error popup when being in the agenda app

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaEventsUpdater.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaEventsUpdater.vue
@@ -31,7 +31,7 @@ export default {
     },
   },
   created() {
-    this.$agendaWebSocket.initCometd(this.settings.cometdContext, this.settings.cometdToken, this.handleAgendaUpdates);
+    this.$agendaWebSocket.initCometd(this.settings.cometdContextName, this.settings.cometdToken, this.handleAgendaUpdates);
   },
   methods: {
     handleAgendaUpdates(wsEventName, eventModifications) {


### PR DESCRIPTION
**ISSUE**: Wrong passed argument for the cometd context name when configuring the cometd in the agenda app which changed the cometd URL used by agenda and the jitsi web-conferencing when initializing the call button or updating the call state with users
**FIX**: Set the right parameter for the **cometdContextName**