### PR TITLE
49308: added styles to display agenda label chips with ellipsis on mobile

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="event-details-body overflow-auto flex-grow-1 d-flex flex-column flex-md-row pa-4 mt-5">
-    <div class="flex-grow-1 flex-shrink-0 d-flex event-details-body-left">
+    <div class="flex-grow-1 flex-shrink-0 event-details-body-left " :class="{ 'd-flex' : !isMobile }">
       <div class="mx-auto">
         <div class="event-date align-center d-flex pb-5">
           <i class="uiIconDatePicker darkGreyIcon uiIcon32x32 pe-5"></i>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -4,65 +4,45 @@
       <v-list-item-title class="title text-color">
         {{ $t('agenda') }}
       </v-list-item-title>
-      <v-list-item-subtitle class="text-sub-title">
-        <v-list-item v-if="settings" dense>
-          <v-list-item-content class="pa-0">
-            <v-list-item-title class="text-wrap">
-              <template>
-                <v-chip
-                  class="ma-2"
-                  color="primary"
-                  style="max-width:calc(100% - 40px)">
-                  <span class="text-truncate">
-                    <span class="text-capitalize">{{ agendaSelectedView }}</span>
-                    <span class="ps-1">{{ $t('agenda.view') }} </span>
-                  </span>
-                </v-chip>
-                <v-chip
-                  class="ma-2"
-                  color="primary"
-                  style="max-width:calc(100% - 40px)"
-                  >
-                  <span class="text-truncate" >
-                   {{ agendaWeekStartOnLabel }}
-                  </span>
-                </v-chip>
-                <v-chip
-                  v-if="agendaWorkingTime"
-                  class="ma-2"
-                  color="primary"
-                  style="max-width:calc(100% - 40px)"
-                  >
-                  <span class="text-truncate">
-                  {{ agendaWorkingTime }}
-                  </span>
-                
-                </v-chip>
-                <template v-if="settings.reminders">
-                  <v-chip
-                    v-for="(reminder, index) in settings.reminders"
-                    :key="index"
-                    class="ma-2"
-                    color="primary"
-                    style="max-width:calc(100% - 40px)">
-                    <template v-if="reminder.before">
-                      <span class="text-truncate">
-                       {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
-                      </span>
-                      </template>
-                    <template v-else>
-                      <span class="text-truncate">
-                      {{ $t('agenda.label.notifyMeWhenEventStarts') }}
-                       </span>
-                    </template>
-                    
-                  </v-chip>
-                </template>
+      <v-flex v-if="settings" class="d-flex flex-wrap">
+        <v-chip
+          class="ma-2"
+          color="primary">
+          <span class="text-capitalize">{{ agendaSelectedView }}</span>
+          <span class="ps-1">{{ $t('agenda.view') }}</span>
+        </v-chip>
+        <v-chip
+          class="ma-2"
+          color="primary">
+          <div class="text-truncate">
+            {{ agendaWeekStartOnLabel }}
+          </div>
+        </v-chip>
+        <v-chip
+          v-if="agendaWorkingTime"
+          class="ma-2"
+          color="primary">
+          <div class="text-truncate">
+            {{ agendaWorkingTime }}
+          </div>
+        </v-chip>
+        <template v-if="settings.reminders">
+          <v-chip
+            v-for="(reminder, index) in settings.reminders"
+            :key="index"
+            class="ma-2"
+            color="primary">
+            <div class="text-truncate">
+              <template v-if="reminder.before">
+                {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
+               </template>
+               <template v-else>
+                {{ $t('agenda.label.notifyMeWhenEventStarts') }}
               </template>
-            </v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </v-list-item-subtitle>
+            </div>
+          </v-chip>
+        </template>
+      </v-flex>
     </v-list-item-content>
     <v-list-item-action>
       <v-btn

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -11,26 +11,29 @@
               <template>
                 <v-chip
                   class="ma-2"
-                  color="primary">
-                  <span class="text-capitalize">{{ agendaSelectedView }}</span>
-                  <span class="ps-1">
-                    <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
-                    {{ $t('agenda.view') }}
-                    </span>
+                  color="primary"
+                  style="max-width:calc(100% - 40px)">
+                  <span class="text-truncate">
+                    <span class="text-capitalize">{{ agendaSelectedView }}</span>
+                    <span class="ps-1">{{ $t('agenda.view') }} </span>
                   </span>
                 </v-chip>
                 <v-chip
                   class="ma-2"
-                  color="primary">
-                  <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
+                  color="primary"
+                  style="max-width:calc(100% - 40px)"
+                  >
+                  <span class="text-truncate" >
                    {{ agendaWeekStartOnLabel }}
                   </span>
                 </v-chip>
                 <v-chip
                   v-if="agendaWorkingTime"
                   class="ma-2"
-                  color="primary">
-                  <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
+                  color="primary"
+                  style="max-width:calc(100% - 40px)"
+                  >
+                  <span class="text-truncate">
                   {{ agendaWorkingTime }}
                   </span>
                 
@@ -40,15 +43,19 @@
                     v-for="(reminder, index) in settings.reminders"
                     :key="index"
                     class="ma-2"
-                    color="primary">
+                    color="primary"
+                    style="max-width:calc(100% - 40px)">
                     <template v-if="reminder.before">
-                      <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
+                      <span class="text-truncate">
                        {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
                       </span>
                       </template>
                     <template v-else>
+                      <span class="text-truncate">
                       {{ $t('agenda.label.notifyMeWhenEventStarts') }}
+                       </span>
                     </template>
+                    
                   </v-chip>
                 </template>
               </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -35,12 +35,10 @@
                     class="ma-2"
                     color="primary">
                     <template v-if="reminder.before">
-                      <span v-if="isMobile" class="mobile-chip-ellipsis">
-                      {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
-                      </span>
-                      <span v-else>
+                      <span class="{ mobile-chip-ellipsis : isMobile }">
                         {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
-                      </span>                    </template>
+                      </span>                   
+                      </template>
                     <template v-else>
                       {{ $t('agenda.label.notifyMeWhenEventStarts') }}
                     </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -42,7 +42,7 @@
                     class="ma-2"
                     color="primary">
                     <template v-if="reminder.before">
-                      <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'140px'} : {}">
+                      <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
                        {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
                       </span>
                       </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -13,20 +13,27 @@
                   class="ma-2"
                   color="primary">
                   <span class="text-capitalize">{{ agendaSelectedView }}</span>
-                  <span class="ps-1">{{ $t('agenda.view') }}</span>
+                  <span class="ps-1">
+                    <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
+                    {{ $t('agenda.view') }}
+                    </span>
+                  </span>
                 </v-chip>
                 <v-chip
                   class="ma-2"
                   color="primary">
-                  {{ agendaWeekStartOnLabel }}
+                  <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
+                   {{ agendaWeekStartOnLabel }}
+                  </span>
                 </v-chip>
                 <v-chip
                   v-if="agendaWorkingTime"
                   class="ma-2"
                   color="primary">
-                  <span class="{ mobile-chip-ellipsis : isMobile }">
+                  <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'130px'} : {}">
                   {{ agendaWorkingTime }}
                   </span>
+                
                 </v-chip>
                 <template v-if="settings.reminders">
                   <v-chip
@@ -35,9 +42,9 @@
                     class="ma-2"
                     color="primary">
                     <template v-if="reminder.before">
-                      <span class="{ mobile-chip-ellipsis : isMobile }">
-                        {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
-                      </span>                   
+                      <span :class="[isMobile ? ['d-inline-block','text-truncate'] : ''] " :style= "isMobile ? {'max-width':'140px'} : {}">
+                       {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
+                      </span>
                       </template>
                     <template v-else>
                       {{ $t('agenda.label.notifyMeWhenEventStarts') }}

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -90,9 +90,6 @@ export default {
       .toString()}`,
   }),
   computed: {
-    isMobile() {
-      return this.$vuetify && this.$vuetify.breakpoint && this.$vuetify.breakpoint.name === 'xs';
-    },
     DAY_NAME_BY_ABBREVIATION () {
       return {
         'MO': this.getDayFromAbbreviation('MO'),

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -24,7 +24,10 @@
                   v-if="agendaWorkingTime"
                   class="ma-2"
                   color="primary">
+                  <span v-if="isMobile" class="mobile-chip-ellipsis">
                   {{ agendaWorkingTime }}
+                  </span>
+                  <span v-else>{{ agendaWorkingTime }}</span>
                 </v-chip>
                 <template v-if="settings.reminders">
                   <v-chip
@@ -33,8 +36,12 @@
                     class="ma-2"
                     color="primary">
                     <template v-if="reminder.before">
+                      <span v-if="isMobile" class="mobile-chip-ellipsis">
                       {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
-                    </template>
+                      </span>
+                      <span v-else>
+                        {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
+                      </span>                    </template>
                     <template v-else>
                       {{ $t('agenda.label.notifyMeWhenEventStarts') }}
                     </template>
@@ -72,6 +79,9 @@ export default {
       .toString()}`,
   }),
   computed: {
+    isMobile() {
+      return this.$vuetify && this.$vuetify.breakpoint && this.$vuetify.breakpoint.name === 'xs';
+    },
     DAY_NAME_BY_ABBREVIATION () {
       return {
         'MO': this.getDayFromAbbreviation('MO'),

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -24,10 +24,9 @@
                   v-if="agendaWorkingTime"
                   class="ma-2"
                   color="primary">
-                  <span v-if="isMobile" class="mobile-chip-ellipsis">
+                  <span class="{ mobile-chip-ellipsis : isMobile }">
                   {{ agendaWorkingTime }}
                   </span>
-                  <span v-else>{{ agendaWorkingTime }}</span>
                 </v-chip>
                 <template v-if="settings.reminders">
                   <v-chip


### PR DESCRIPTION
ISSUE: in the settings page we need to display the blue label chips with ellipsis for mobile web
FIX: added custom style that will be applied to these chips only when the application is opened on a mobile browser