### PR TITLE
52458 : Fix a JS error when creating an event

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -189,7 +189,7 @@ export default {
       }
     },
     eventOwner(newVal) {
-      if (newVal.providerId) {
+      if (newVal && newVal.providerId) {
         this.$identityService.getIdentityByProviderIdAndRemoteId(newVal.providerId, newVal.remoteId)
           .then(identity => {
             this.event.calendar.owner.id = identity.id;


### PR DESCRIPTION
When creating a new event from Snapshot page, we got a JS error when saving.
This fix will make sure that the watched property is not null before looking for the user identity from Social API