### PR TITLE
TASK-42616 : DatePoll - Notifications refers to technical label of the space

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -720,11 +720,12 @@ public class NotificationUtils {
   private static final void setSpaceName(NotificationInfo notification, TemplateContext templateContext) {
     String ownerId = notification.getValueOwnerParameter(STORED_PARAMETER_EVENT_OWNER_ID);
     IdentityManager identityManager = ExoContainerContext.getService(IdentityManager.class);
+    SpaceService spaceService = ExoContainerContext.getService(SpaceService.class);
     Identity identity = identityManager.getIdentity(ownerId);
     if (identity == null) {
       templateContext.put(TEMPLATE_VARIABLE_AGENDA_NAME, "");
     } else {
-      String spaceName = identity.getRemoteId();
+      String spaceName = spaceService.getSpaceByPrettyName(identity.getRemoteId()).getDisplayName();
       templateContext.put(TEMPLATE_VARIABLE_AGENDA_NAME, spaceName);
     }
   }


### PR DESCRIPTION
ISSUE : display technical label of space's name in the description of the notification and the email template when adding a date poll while creating an event.
FIX : change the space's name label in the description of the notification and the email which will be sent to the receiver user.