### PR TITLE
49308: added styles to display agenda label chips with ellipsis on mobile

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="event-details-body overflow-auto flex-grow-1 d-flex flex-column flex-md-row pa-4 mt-5">
-    <div class="flex-grow-1 flex-shrink-0 d-flex event-details-body-left">
+    <div class="flex-grow-1 flex-shrink-0 event-details-body-left " :class="{ 'd-flex' : !isMobile }">
       <div class="mx-auto">
         <div class="event-date align-center d-flex pb-5">
           <i class="uiIconDatePicker darkGreyIcon uiIcon32x32 pe-5"></i>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserGeneralSettings.vue
@@ -4,47 +4,45 @@
       <v-list-item-title class="title text-color">
         {{ $t('agenda') }}
       </v-list-item-title>
-      <v-list-item-subtitle class="text-sub-title">
-        <v-list-item v-if="settings" dense>
-          <v-list-item-content class="pa-0">
-            <v-list-item-title class="text-wrap">
-              <template>
-                <v-chip
-                  class="ma-2"
-                  color="primary">
-                  <span class="text-capitalize">{{ agendaSelectedView }}</span>
-                  <span class="ps-1">{{ $t('agenda.view') }}</span>
-                </v-chip>
-                <v-chip
-                  class="ma-2"
-                  color="primary">
-                  {{ agendaWeekStartOnLabel }}
-                </v-chip>
-                <v-chip
-                  v-if="agendaWorkingTime"
-                  class="ma-2"
-                  color="primary">
-                  {{ agendaWorkingTime }}
-                </v-chip>
-                <template v-if="settings.reminders">
-                  <v-chip
-                    v-for="(reminder, index) in settings.reminders"
-                    :key="index"
-                    class="ma-2"
-                    color="primary">
-                    <template v-if="reminder.before">
-                      {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
-                    </template>
-                    <template v-else>
-                      {{ $t('agenda.label.notifyMeWhenEventStarts') }}
-                    </template>
-                  </v-chip>
-                </template>
+      <v-flex v-if="settings" class="d-flex flex-wrap">
+        <v-chip
+          class="ma-2"
+          color="primary">
+          <span class="text-capitalize">{{ agendaSelectedView }}</span>
+          <span class="ps-1">{{ $t('agenda.view') }}</span>
+        </v-chip>
+        <v-chip
+          class="ma-2"
+          color="primary">
+          <div class="text-truncate">
+            {{ agendaWeekStartOnLabel }}
+          </div>
+        </v-chip>
+        <v-chip
+          v-if="agendaWorkingTime"
+          class="ma-2"
+          color="primary">
+          <div class="text-truncate">
+            {{ agendaWorkingTime }}
+          </div>
+        </v-chip>
+        <template v-if="settings.reminders">
+          <v-chip
+            v-for="(reminder, index) in settings.reminders"
+            :key="index"
+            class="ma-2"
+            color="primary">
+            <div class="text-truncate">
+              <template v-if="reminder.before">
+                {{ $t('agenda.label.notifyMeBefore', {0: reminder.before, 1: $t(`agenda.option.${reminder.beforePeriodType.toLowerCase()}s`).toLowerCase()}) }}
+               </template>
+               <template v-else>
+                {{ $t('agenda.label.notifyMeWhenEventStarts') }}
               </template>
-            </v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </v-list-item-subtitle>
+            </div>
+          </v-chip>
+        </template>
+      </v-flex>
     </v-list-item-content>
     <v-list-item-action>
       <v-btn


### PR DESCRIPTION
ISSUE: in the settings page we need to display the blue label chips with ellipsis for mobile web
FIX: applying a different wrapper to the v-chip components as to conserve their default resizing behavior