### PR TITLE
52868 : No need to set onlyManagers with onlyRedactors 

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormCalendarOwner.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormCalendarOwner.vue
@@ -10,7 +10,6 @@
     class="user-suggester calendarOwnerAutocomplete"
     include-spaces
     only-redactor
-    only-manager
     required />
 </template>
 


### PR DESCRIPTION
We can have the option to include just spaces where I am redactor, no need to set onlyManager option as it is included by default. All managers are redactors already thus when I set onlyRedactor, I will get the list of spaces where I am redactor or manager