### PR TITLE
TASK-45263: event invitation shows number instead of user names.

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -823,7 +823,9 @@ public class NotificationUtils {
 
   private static String getFullUserName(Set<String> participants, IdentityManager identityManager) {
     if (participants.size() > 3) {
-      List<String> showParticipants = participants.stream().limit(3).collect(Collectors.toList());
+      List<String> showParticipants = participants.stream().limit(3).map(participant -> {
+        return Utils.getIdentityById(identityManager, participant).getProfile().getFullName();
+      }).collect(Collectors.toList());
       return String.join(", ", showParticipants).concat("...");
     } else {
       List<String> showParticipants = participants.stream().map(participant -> {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -826,10 +826,9 @@ public class NotificationUtils {
             Utils.getIdentityById(identityManager, participant).getProfile().getFullName()
     ).collect( Collectors.joining( ", " ) );
     if (participants.size() > 3) {
-      return showParticipants.concat("...");
-    } else {
-      return showParticipants;
+      showParticipants=showParticipants.concat("...");
     }
+    return showParticipants;
   }
 
   private static String getSpaceDisplayName(Set<String> participants, SpaceService spaceService) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -822,16 +822,13 @@ public class NotificationUtils {
   }
 
   private static String getFullUserName(Set<String> participants, IdentityManager identityManager) {
+    String showParticipants = participants.stream().limit(3).map(participant ->
+            Utils.getIdentityById(identityManager, participant).getProfile().getFullName()
+    ).collect( Collectors.joining( ", " ) );
     if (participants.size() > 3) {
-      List<String> showParticipants = participants.stream().limit(3).map(participant ->
-      Utils.getIdentityById(identityManager, participant).getProfile().getFullName()
-      ).collect(Collectors.toList());
-      return String.join(", ", showParticipants).concat("...");
+      return showParticipants.concat("...");
     } else {
-      List<String> showParticipants = participants.stream().map(participant -> {
-        return Utils.getIdentityById(identityManager, participant).getProfile().getFullName();
-      }).collect(Collectors.toList());
-      return String.join(", ", showParticipants);
+      return showParticipants;
     }
   }
 

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -822,11 +822,14 @@ public class NotificationUtils {
   }
 
   private static String getFullUserName(Set<String> participants, IdentityManager identityManager) {
-    String showParticipants = participants.stream().limit(3).map(participant ->
-            Utils.getIdentityById(identityManager, participant).getProfile().getFullName()
-    ).collect( Collectors.joining( ", " ) );
+    String showParticipants = participants.stream()
+                                          .limit(3)
+                                          .map(participant -> Utils.getIdentityById(identityManager, participant)
+                                                                   .getProfile()
+                                                                   .getFullName())
+                                          .collect(Collectors.joining(", "));
     if (participants.size() > 3) {
-      showParticipants=showParticipants.concat("...");
+      showParticipants = showParticipants.concat("...");
     }
     return showParticipants;
   }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -823,9 +823,9 @@ public class NotificationUtils {
 
   private static String getFullUserName(Set<String> participants, IdentityManager identityManager) {
     if (participants.size() > 3) {
-      List<String> showParticipants = participants.stream().limit(3).map(participant -> {
-        return Utils.getIdentityById(identityManager, participant).getProfile().getFullName();
-      }).collect(Collectors.toList());
+      List<String> showParticipants = participants.stream().limit(3).map(participant ->
+      Utils.getIdentityById(identityManager, participant).getProfile().getFullName()
+      ).collect(Collectors.toList());
       return String.join(", ", showParticipants).concat("...");
     } else {
       List<String> showParticipants = participants.stream().map(participant -> {


### PR DESCRIPTION
ISSUES : event invitation shows number instead of user names.
FIX : when editing an event and adding participants ,if the number of participants is higher than 3, the email received displays numbers instead of user names and and it is fixed by changing the userId by Fullname when the number of participants is higher than 3.