### PR TITLE
Task-54003 : Composed last name truncated in agenda notifications (#384)

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -801,8 +801,9 @@ public class NotificationUtils {
   }
 
   private static final String getEventNotificationCreatorOrModifierUserName(Identity identity) {
-    String[] splited = identity.getProfile().getFullName().split(" ");
-    String fullName = StringUtils.capitalize(splited[0]).concat(" ").concat(StringUtils.capitalize(splited[1]));
+    String fullName = Arrays.stream(identity.getProfile().getFullName().split(" "))
+            .map(t -> t.substring(0, 1).toUpperCase() + t.substring(1))
+            .collect(Collectors.joining(" "));
     if(Utils.isExternal(identity.getRemoteId())) {
       fullName += " " + "(" + Utils.getResourceBundleLabel(new Locale(Utils.getUserLanguage(identity.getRemoteId())), "external.label.tag") + ")";
     }


### PR DESCRIPTION
ISSUES :  Composed last name truncated in agenda notifications.
FIX : to solve this issue  I modified in the function 'getEventNotificationCreatorOrModifierUserName' exactly in the logic of splite of fullName because this function take into consideration only the fullName compser by two words.