### PR TITLE
TASK-45263: event invitation shows number instead of user names. (#387)

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -822,15 +822,16 @@ public class NotificationUtils {
   }
 
   private static String getFullUserName(Set<String> participants, IdentityManager identityManager) {
+    String showParticipants = participants.stream()
+                                          .limit(3)
+                                          .map(participant -> Utils.getIdentityById(identityManager, participant)
+                                                                   .getProfile()
+                                                                   .getFullName())
+                                          .collect(Collectors.joining(", "));
     if (participants.size() > 3) {
-      List<String> showParticipants = participants.stream().limit(3).collect(Collectors.toList());
-      return String.join(", ", showParticipants).concat("...");
-    } else {
-      List<String> showParticipants = participants.stream().map(participant -> {
-        return Utils.getIdentityById(identityManager, participant).getProfile().getFullName();
-      }).collect(Collectors.toList());
-      return String.join(", ", showParticipants);
+      showParticipants = showParticipants.concat("...");
     }
+    return showParticipants;
   }
 
   private static String getSpaceDisplayName(Set<String> participants, SpaceService spaceService) {


### PR DESCRIPTION
ISSUES : event invitation shows number instead of user names.
FIX : when editing an event and adding participants ,if the number of participants is higher than 3, the email received displays numbers instead of user names and and it is fixed by changing the userId by Fullname when the number of participants is higher than 3.