### PR TITLE
Task-54516: Event list not displayed after changing timezone.

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/AgendaUtils.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/AgendaUtils.js
@@ -84,8 +84,8 @@ export function initEventForm(agendaEvent, deleteDates) {
 
 export function getUserTimezone() {
   const timeZoneOffset = - (new Date().getTimezoneOffset());
-  let timezoneHours = timeZoneOffset / 60;
-  let timezoneMinutes = timeZoneOffset % 60;
+  let timezoneHours = Math.abs(parseInt(timeZoneOffset / 60));
+  let timezoneMinutes = Math.abs(parseInt(timeZoneOffset % 60));
   timezoneHours = timezoneHours < 10 ? `0${timezoneHours}` : timezoneHours;
   timezoneMinutes = timezoneMinutes < 10 ? `0${timezoneMinutes}` : timezoneMinutes;
   const timezoneSign = timeZoneOffset >= 0 ? '+' : '-';


### PR DESCRIPTION
Problem: if your agenda is synchronized with google calendar . when clicking on event .all events on the same day were displaying but when we change time zone we can't find those events .SO the problem was in the incorrect format user's timezone. that's why the response status of the callback was 400 (bad request ) invalid parameters.

Fix: in this fix, we formatted the time zone of the user as it should be (hh:mm) And of course with the sign that should be in front of hours.