### PR TITLE
task-45906: snapshot agenda shows past events of today (#398)

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -188,7 +188,7 @@ export default {
       this.loading = true;
       const userIdentityId = this.eventType === 'myEvents' && eXo.env.portal.userIdentityId || null;
       const responseTypes = ['ACCEPTED','TENTATIVE'];
-      return this.$eventService.getEvents(this.searchTerm, this.ownerIds, userIdentityId, this.$agendaUtils.toRFC3339(this.period.start, true), this.$agendaUtils.toRFC3339(this.period.end), this.limit, responseTypes)
+      return this.$eventService.getEvents(this.searchTerm, this.ownerIds, userIdentityId, this.$agendaUtils.toRFC3339(this.period.start, false), this.$agendaUtils.toRFC3339(this.period.end), this.limit, responseTypes)
         .then(data => {
           const events = data && data.events || [];
           events.forEach(event => {


### PR DESCRIPTION
in agenda widget of snapshot page, the time, when retrieiving events, was ignored (ignoreTime parameter in toRFC3339 method was set to true) which makes that all events, since the beginning of the current day, are retrieved.
after this change, events whose time has passed will no longer be listed