### PR TITLE
Task-55889: Fix Drawer datepicker select n+1 for months

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDatePickers.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDatePickers.vue
@@ -93,7 +93,7 @@ export default {
         return;
       }
       const date = this.$agendaUtils.toDate(this.startDate);
-      const newDate = this.$agendaUtils.toDate(this.event.startDate);
+      const newDate = this.$agendaUtils.toDate(date);
       newDate.setFullYear(date.getFullYear());
       newDate.setMonth(date.getMonth());
       newDate.setDate(date.getDate());


### PR DESCRIPTION
Prior to this change, when i change the date of my pc 31/03 then go to agenda application , then sleect a date On april to add an event then drawer is opned , chose the datepicker a day on april .
This is due to the fact the day chosen well be added but on Day(month+1)
After this change, we ensure that when i chose a date on april , well be added correctly , so the day when you choose is the event day selected.