### PR TITLE
Task-55604: Event creation link on agenda (add inviteId).

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
@@ -107,7 +107,7 @@ function updateConference(event, conference) {
       });
     })
     .then(callDetails => {
-      conference.url = callDetails.url;
+      conference.url = callDetails.inviteId ? `${callDetails.url}?inviteId=${callDetails.inviteId}` : conference.url;
       return conference;
     })
     .catch(() => createConference(event, conference));


### PR DESCRIPTION
Problem: when editing a webConference event and save it ,a link without the parameter invited was generated.
Fix : get the old value of conference url when the returned  attribute inviteId is null.