### PR TITLE
Task-56257 : JS error when removing event containing a webconference link

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
@@ -41,7 +41,7 @@ export function saveEventWebConferencing(event, conference) {
   }
 }
 
-function deleteConference(provider, url) {
+function deleteConference(url) {
   return global.webConferencing.getCallId(url)
     .then(callId => {
       if (!callId) {


### PR DESCRIPTION
Before this fix, when I remove an event containing a webconference link, there is a js error in console
This error is due to the function deleteConference which wait for 2 parameters (provider and url), but only the second one (url is used). But the only way this function is called, it is with one parameter : url.
So in the function, the url is read as the provider, which is a not used parameter

This fix remove the provider parameter which is not used