### PR TITLE
TASK-55889 Fix End Date computing in Event Form (#420) (#422)

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
@@ -1,20 +1,26 @@
 <template>
   <v-flex class="user-suggester text-truncate">
-    <exo-identity-suggester
-      ref="invitedAttendeeAutoComplete"
-      v-model="invitedAttendee"
-      :labels="participantSuggesterLabels"
-      :title="suggesterStatus"
-      :disabled="disableAttendeeSuggester"
-      :ignore-items="ignoredMembers"
-      :search-options="searchOptions"
-      name="inviteAttendee"
-      no-redactor-space
-      include-users
-      include-spaces />
-    <span v-if="disableAttendeeSuggester" class="error--text">
-      {{ $t('agenda.suggesterRequired') }}
-    </span>
+    <form
+      ref="form"
+      @keypress="checkGuestInvitation($event)">
+      <exo-identity-suggester
+        ref="invitedAttendeeAutoComplete"
+        v-model="invitedAttendee"
+        :labels="participantSuggesterLabels"
+        :title="suggesterStatus"
+        :disabled="disableAttendeeSuggester"
+        :ignore-items="ignoredMembers"
+        :search-options="searchOptions"
+        name="inviteAttendee"
+        no-redactor-space
+        include-users
+        include-spaces />
+      <span v-if="disableAttendeeSuggester" class="error--text">
+        {{ $t('agenda.suggesterRequired') }}
+      </span>
+    </form>
+    <agenda-notification-alerts v-if="displayAlert" name="event-form" />
+
     <div v-if="event.attendees" class="identitySuggester no-border mt-0">
       <agenda-event-form-attendee-item
         v-for="attendee in event.attendees"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDatePickers.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDatePickers.vue
@@ -94,9 +94,11 @@ export default {
       }
       const date = this.$agendaUtils.toDate(this.startDate);
       const newDate = this.$agendaUtils.toDate(this.event.startDate);
-      newDate.setFullYear(date.getFullYear());
+      const day = date.getDate();
+      newDate.setDate(1);
       newDate.setMonth(date.getMonth());
-      newDate.setDate(date.getDate());
+      newDate.setFullYear(date.getFullYear());
+      newDate.setDate(day);
       this.event.startDate = newDate;
       this.event.start = this.$agendaUtils.toRFC3339(this.event.startDate);
       this.endDate = this.$agendaUtils.toDate(newDate.getTime() + this.duration);

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/AgendaUtils.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/AgendaUtils.js
@@ -193,7 +193,11 @@ export function toDate(date) {
     return new Date(date);
   } else if (typeof date === 'string') {
     if (date.indexOf('T') === 10 && date.length > 19) {
-      date = date.substring(0, 19);
+      // Delete TimeZone information
+      return new Date(date.substring(0, 19));
+    } else if (date.length === 10) {
+      // Ensure that TimeZone information doesn't alter the real day of the event
+      return new Date(`${date} 00:00:00`);
     }
     return new Date(date);
   } else if (typeof date === 'object') {


### PR DESCRIPTION
Prior to this change, in event form, when switching start date to March 31, than attempt to select a date from April (finishes at 30 and doesn't have 31), the end date is switched to May. This is due to changing the month before the day of the month, will lead to slide to the next month. This fix will change the day of the month to a temporary value (1) before switching the year and month.