### PR TITLE
TASK-55025: Fix agenda widget on the snapshot page

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -786,6 +786,7 @@
   }
   .agenda-timeline {
     display: flex;
+    flex-direction: column;
     min-height: ~"calc(100% - 53px)";
     flex: 1 1 auto;
     max-width: 100%;


### PR DESCRIPTION
ISSUES : In snapshot page,Agenda widget display the next events planned in this month and if you have less than 10 events it doesn’t display events of next month.
FIX : The problem is that events are badly displayed with the proprty display:flex which defaults to row direction, which is fixed by adding the proprty flex-direction: column.