### PR TITLE
TASK-57601: fix close button does not appear on mobile

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
@@ -10,7 +10,7 @@
       class="mx-3 my-auto spaceAvatar space-avatar-header">
       <v-img :src="ownerAvatarUrl" />
     </v-avatar>
-    <div class="d-flex flex-grow-1 flex-column align-left">
+    <div class="d-block text-truncate flex-grow-1 align-left">
       <strong :title="event.summary" class="event-header-title text-truncate">
         {{ event.summary }}
       </strong>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
@@ -1,28 +1,25 @@
 <template>
-<v-container>
-  <v-row align="start" no-gutters >
-    <v-col cols="1" class="mt-1 ml-n2">
-      <v-avatar
-        height="32"
-        min-height="32"
-        width="32"
-        min-width="32"
-        max-width="32"
-        size="32"
-        class="mx-3 my-auto spaceAvatar space-avatar-header">
-        <v-img :src="ownerAvatarUrl" />
-      </v-avatar>
-    </v-col>
-    <v-col cols="8" class="text-truncate ml-6">
-      <strong :title="event.summary" class="event-header-title">
+  <div class="d-flex flex-row py-2">
+    <v-avatar
+      height="32"
+      min-height="32"
+      width="32"
+      min-width="32"
+      max-width="32"
+      size="32"
+      class="mx-3 my-auto spaceAvatar space-avatar-header">
+      <v-img :src="ownerAvatarUrl" />
+    </v-avatar>
+    <div class="d-flex flex-grow-1 flex-column align-left">
+      <strong :title="event.summary" class="event-header-title text-truncate">
         {{ event.summary }}
       </strong>
       <div class="text-truncate d-flex">
         <span>{{ $t('agenda.label.in') }}</span>
         <a :href="calendarOwnerLink" class="text-truncate calendar-owner-link ps-1">{{ ownerDisplayName }}</a>
       </div>
-    </v-col>
-    <v-col cols="1">
+    </div>
+    <div class="d-flex flex-grow-0">
       <v-menu
         v-if="canEdit"
         bottom
@@ -50,8 +47,8 @@
           </v-list-item>
         </v-list>
       </v-menu>
-    </v-col>
-    <v-col cols="1" class="ml-n2 mr-2">
+    </div>
+    <div class="d-flex flex-grow-0">
       <v-btn
         class="my-auto me-2"
         color="grey"
@@ -61,9 +58,8 @@
           mdi-close
         </v-icon>
       </v-btn>
-    </v-col>
-  </v-row>
-  </v-container>
+    </div>
+  </div>
 </template>
 <script>
 export default {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
@@ -1,25 +1,28 @@
 <template>
-  <div class="d-flex flex-row py-2">
-    <v-avatar
-      height="32"
-      min-height="32"
-      width="32"
-      min-width="32"
-      max-width="32"
-      size="32"
-      class="mx-3 my-auto spaceAvatar space-avatar-header">
-      <v-img :src="ownerAvatarUrl" />
-    </v-avatar>
-    <div class="d-flex flex-grow-1 flex-column align-left">
-      <strong :title="event.summary" class="event-header-title text-truncate">
+<v-container>
+  <v-row align="start" no-gutters >
+    <v-col cols="1" class="mt-1 ml-n2">
+      <v-avatar
+        height="32"
+        min-height="32"
+        width="32"
+        min-width="32"
+        max-width="32"
+        size="32"
+        class="mx-3 my-auto spaceAvatar space-avatar-header">
+        <v-img :src="ownerAvatarUrl" />
+      </v-avatar>
+    </v-col>
+    <v-col cols="8" class="text-truncate ml-6">
+      <strong :title="event.summary" class="event-header-title">
         {{ event.summary }}
       </strong>
       <div class="text-truncate d-flex">
         <span>{{ $t('agenda.label.in') }}</span>
         <a :href="calendarOwnerLink" class="text-truncate calendar-owner-link ps-1">{{ ownerDisplayName }}</a>
       </div>
-    </div>
-    <div class="d-flex flex-grow-0">
+    </v-col>
+    <v-col cols="1">
       <v-menu
         v-if="canEdit"
         bottom
@@ -47,8 +50,8 @@
           </v-list-item>
         </v-list>
       </v-menu>
-    </div>
-    <div class="d-flex flex-grow-0">
+    </v-col>
+    <v-col cols="1" class="ml-n2 mr-2">
       <v-btn
         class="my-auto me-2"
         color="grey"
@@ -58,8 +61,9 @@
           mdi-close
         </v-icon>
       </v-btn>
-    </div>
-  </div>
+    </v-col>
+  </v-row>
+  </v-container>
 </template>
 <script>
 export default {


### PR DESCRIPTION
ISSUE: The close button for an event invitation page does not appear on mobile. This happens because the text for the event title doesn't get truncated properly if it's too long.
FIX: refactored this toolbar mobile component so that it uses 'v-row' s and 'v-col 's to define the layout.