### PR TITLE
TASK-57601: fix close button does not appear on mobile

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/mobile/AgendaEventDetailsMobileToolbar.vue
@@ -10,7 +10,7 @@
       class="mx-3 my-auto spaceAvatar space-avatar-header">
       <v-img :src="ownerAvatarUrl" />
     </v-avatar>
-    <div class="d-flex flex-grow-1 flex-column align-left">
+    <div class="d-block text-truncate flex-grow-1 align-left">
       <strong :title="event.summary" class="event-header-title text-truncate">
         {{ event.summary }}
       </strong>


### PR DESCRIPTION
ISSUE: The close button for an event invitation page does not appear on mobile. This happens because the text for the event title doesn't get truncated properly if it's too long.
FIX: added d-block and text_truncate css classes the div containing the event title