### PR TITLE
TASK-54594 permit to managers, redactors, and super manager to edit events in space.

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -424,7 +424,7 @@ public class Utils {
       boolean isManager = space != null && spaceService.isManager(space, userIdentity.getRemoteId());
       boolean isRedactor = space != null && spaceService.isRedactor(space, userIdentity.getRemoteId());
       boolean spaceHasARedactor = space != null && space.getRedactors() != null && space.getRedactors().length > 0;
-      return (!spaceHasARedactor || isRedactor) && (superManager || isManager);
+      return (spaceHasARedactor && isRedactor) || superManager || isManager;
     } else {
       return false;
     }


### PR DESCRIPTION
Problem: Prior this change, if a space contains a redactor many problems is appeared .A member of space cannot edit events, whatever the role (super manager, redactor, manager) except of  event creator. On technical side,there is  incorrect logical expression returned by this method `canEditCalendar()`.
Fix: after fixing returned values of these two methods,the current behavior is:
-super manager , manager and redactors, can edit all events in space .
-the owner of event can always edit it
-toggle button "modify event" is enabled if a space has no redactor else it remains disabled for all