### PR TITLE
Task-57951: Display Exchange agenda connector in "Connect You Personal Agenda" user setting drawer

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
@@ -62,14 +62,13 @@
             <div class="d-flex">
               <span class="my-auto pe-4">
                 <v-icon
-              size="18"
-              class=""
-              color="grey"
-              depressed>
-              fa-info-circle
-            </v-icon>
+                    size="16"
+                    class="text-light-color"
+                    depressed>
+                  fa-info-circle
+                </v-icon>
               </span>
-              <span class="my-auto me-auto grey--text font-italic">
+              <span class="my-auto me-auto font-italic text-light-color">
                 {{ $t('agenda.allowedToConnectOnlyOneConnector') }}
               </span>
             </div>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
@@ -14,7 +14,7 @@
         <v-list-item
           v-for="connector in enabledConnectors"
           :key="connector.name">
-          <v-list-item-avatar>
+          <v-list-item-avatar class="rounded-0">
             <v-avatar tile size="40">
               <img :src="connector.avatar">
             </v-avatar>
@@ -60,10 +60,16 @@
         <v-list-item>
           <v-list-item-content>
             <div class="d-flex">
-              <span class="my-auto ms-auto pt-4 pe-2">
-                <i class="uiIconColorWarning"></i>
+              <span class="my-auto pe-4">
+                <v-icon
+              size="18"
+              class=""
+              color="grey"
+              depressed>
+              fa-info-circle
+            </v-icon>
               </span>
-              <span class="my-auto me-auto">
+              <span class="my-auto me-auto grey--text font-italic">
                 {{ $t('agenda.allowedToConnectOnlyOneConnector') }}
               </span>
             </div>


### PR DESCRIPTION
After this change, we will be able to display Exchange agenda connector in the list of connectors of "Connect You Personal Agenda" user setting drawer in addition of enhancing the connectors icons size and color.