### PR TITLE
TASK-58004: Improve Connect Personal Agenda drawer on Event display

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/exchange-connector/agendaExchangeConnector.js
+++ b/agenda-webapps/src/main/webapp/vue-app/exchange-connector/agendaExchangeConnector.js
@@ -21,7 +21,7 @@ export default {
   isOauth: false,
   canConnect: true,
   canPush: false,
-  initialized: false,
+  initialized: true,
   isSignedIn: false,
   pushing: false,
 };


### PR DESCRIPTION
After this change we can display the new exchange connector in the personal agenda drawer of the event details, the problem is that connectors are filtered by the initialized attribute true, so it is solved by setting the initialized attribute of the exchange connector true.