### PR TITLE
Task-55928: conference link is lost when scheduling an event on mobile application

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
@@ -186,6 +186,26 @@ export default {
   mounted() {
     this.reset();
   },
+  watch: {
+    conferenceURL(newVal) {
+      if (!newVal) {
+        this.event.conferences = [];
+      } else {
+        this.event.conferences = [{
+          url: newVal,
+          type: 'manual',
+        }];
+      }
+    },
+    eventOwner(newVal) {
+      if (newVal && newVal.providerId && !this.event.calendar.owner.id ) {
+        this.$identityService.getIdentityByProviderIdAndRemoteId(newVal.providerId, newVal.remoteId)
+          .then(identity => {
+            this.event.calendar.owner.id = identity.id;
+          });
+      }
+    }
+  },
   methods: {
     close() {
       this.$emit('close');


### PR DESCRIPTION
Problem: when planning a conference in event using mobile application and save it, the conference is not planned and it's link is not added to the event description.
Fix: we add a method that could catch the ID of the owner in the event calendar so we could specify the space event to generate the URL link of the conference