### PR TITLE
Task-58529: Display popup to confirm switching the connection from an agenda connector to another

### DIFF
--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
@@ -229,10 +229,10 @@ agenda.agendaConnectors=Calendar Connectors
 agenda.noActiveConnectors=No personal calendar connector available
 agenda.noConnectors=No connectors
 
-agenda.confirmConnectDialog.title=Disconnect Personal calendar
-agenda.confirmConnectDialog.message=Are you sure you want to disconnect your personal agenda and connect to a new one ?
-agenda.confirmConnectDialog.okButton=Ok
-agenda.confirmConnectDialog.cancelButton=Cancel
+agenda.agendaConnectors.confirmConnectDialog.title=Disconnect Personal calendar
+agenda.agendaConnectors.confirmConnectDialog.message=Are you sure you want to disconnect your personal agenda and connect to a new one ?
+agenda.agendaConnectors.confirmConnectDialog.ok=Ok
+agenda.agendaConnectors.confirmConnectDialog.cancel=Cancel
 
 agenda.agendaConferences=Agenda Conferences
 agenda.noConferences=No conferences

--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
@@ -229,6 +229,11 @@ agenda.agendaConnectors=Calendar Connectors
 agenda.noActiveConnectors=No personal calendar connector available
 agenda.noConnectors=No connectors
 
+agenda.confirmConnectDialog.title=Disconnect Personal calendar
+agenda.confirmConnectDialog.message=Are you sure you want to disconnect your personal agenda and connect to a new one ?
+agenda.confirmConnectDialog.okButton=Ok
+agenda.confirmConnectDialog.cancelButton=Cancel
+
 agenda.agendaConferences=Agenda Conferences
 agenda.noConferences=No conferences
 

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
@@ -1,93 +1,102 @@
 <template>
-  <exo-drawer
-    ref="agendaConnectorsDrawer"
-    class="agendaConnectorsDrawer"
-    body-classes="hide-scroll decrease-z-index-more"
-    right>
-    <template slot="title">
-      {{ $t('agenda.connectYourPersonalAgenda') }}
-    </template>
-    <template slot="content">
-      <v-list
-        v-if="enabledConnectors && enabledConnectors.length !== 0"
-        two-line>
-        <v-list-item
-          v-for="connector in enabledConnectors"
-          :key="connector.name">
-          <v-list-item-avatar class="rounded-0">
-            <v-avatar tile size="40">
-              <img :src="connector.avatar">
-            </v-avatar>
-          </v-list-item-avatar>
-          <v-list-item-content>
-            <v-alert
-              v-if="!connector.canConnect"
-              type="error"
-              class="my-auto">
-              {{ $t('agenda.connectoInitializationFailed') }}
-            </v-alert>
-            <template v-else-if="connector.connected">
-              <v-list-item-title>
-                {{ $t('agenda.connectedAccountWith') }}:
-              </v-list-item-title>
-              <v-list-item-subtitle :title="connector.user">
-                {{ connector.user }}
-              </v-list-item-subtitle>
-            </template>
-            <template v-else>
-              <v-list-item-title class="title">
-                {{ $t(connector.name) }}
-              </v-list-item-title>
-            </template>
-          </v-list-item-content>
-          <v-list-item-action v-if="connector.canConnect">
-            <v-btn
-              v-if="connector.isSignedIn && connector.user"
-              :loading="connector.loading"
-              class="btn"
-              @click="disconnect(connector)">
-              {{ $t('agenda.disconnect') }}
-            </v-btn>
-            <v-btn
-              v-else
-              :loading="connector.loading"
-              class="btn"
-              @click="connect(connector)">
-              {{ $t('agenda.connect') }}
-            </v-btn>
-          </v-list-item-action>
-        </v-list-item>
-        <v-list-item>
-          <v-list-item-content>
-            <div class="d-flex">
-              <span class="my-auto pe-4">
-                <v-icon
+  <div>
+    <exo-drawer
+      ref="agendaConnectorsDrawer"
+      class="agendaConnectorsDrawer"
+      body-classes="hide-scroll decrease-z-index-more"
+      right>
+      <template slot="title">
+        {{ $t('agenda.connectYourPersonalAgenda') }}
+      </template>
+      <template slot="content">
+        <v-list
+          v-if="enabledConnectors && enabledConnectors.length !== 0"
+          two-line>
+          <v-list-item
+            v-for="connector in enabledConnectors"
+            :key="connector.name">
+            <v-list-item-avatar class="rounded-0">
+              <v-avatar tile size="40">
+                <img :src="connector.avatar">
+              </v-avatar>
+            </v-list-item-avatar>
+            <v-list-item-content>
+              <v-alert
+                v-if="!connector.canConnect"
+                type="error"
+                class="my-auto">
+                {{ $t('agenda.connectoInitializationFailed') }}
+              </v-alert>
+              <template v-else-if="connector.connected">
+                <v-list-item-title>
+                  {{ $t('agenda.connectedAccountWith') }}:
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ connector.user }}
+                </v-list-item-subtitle>
+              </template>
+              <template v-else>
+                <v-list-item-title class="title">
+                  {{ $t(connector.name) }}
+                </v-list-item-title>
+              </template>
+            </v-list-item-content>
+            <v-list-item-action v-if="connector.canConnect">
+              <v-btn
+                v-if="connector.isSignedIn && connector.user"
+                :loading="connector.loading"
+                class="btn"
+                @click="disconnect(connector)">
+                {{ $t('agenda.disconnect') }}
+              </v-btn>
+              <v-btn
+                v-else
+                :loading="connector.loading"
+                class="btn"
+                @click="connect(connector)">
+                {{ $t('agenda.connect') }}
+              </v-btn>
+            </v-list-item-action>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <div class="d-flex">
+                <span class="my-auto pe-4">
+                  <v-icon
                     size="16"
                     class="text-light-color"
                     depressed>
-                  fa-info-circle
-                </v-icon>
-              </span>
-              <span class="my-auto me-auto font-italic text-light-color">
-                {{ $t('agenda.allowedToConnectOnlyOneConnector') }}
-              </span>
-            </div>
-          </v-list-item-content>
-        </v-list-item>
-        <v-card-text v-show="errorMessage" class="errorMessage">
-          <v-alert type="error">
-            {{ errorMessage }}
-          </v-alert>
-        </v-card-text>
-      </v-list>
-      <div
-        v-else
-        class="noEnabledConnectors d-flex flex-column align-center">
-        <i class="uiIconCalRemoteCalendar darkGreyIcon ma-5"></i>
-        <p>{{ $t('agenda.noActiveConnectors') }}</p>
-      </div>
-    </template>
-  </exo-drawer>
+                    fa-info-circle
+                  </v-icon>
+                </span>
+                <span class="my-auto me-auto font-italic text-light-color">
+                  {{ $t('agenda.allowedToConnectOnlyOneConnector') }}
+                </span>
+              </div>
+            </v-list-item-content>
+          </v-list-item>
+          <v-card-text v-show="errorMessage" class="errorMessage">
+            <v-alert type="error">
+              {{ errorMessage }}
+            </v-alert>
+          </v-card-text>
+        </v-list>
+        <div
+          v-else
+          class="noEnabledConnectors d-flex flex-column align-center">
+          <i class="uiIconCalRemoteCalendar darkGreyIcon ma-5"></i>
+          <p>{{ $t('agenda.noActiveConnectors') }}</p>
+        </div>
+      </template>
+    </exo-drawer>
+    <exo-confirm-dialog
+      ref="confirmConnectDialog"
+      :title="confirmConnectDialogLabels.title"
+      :message="confirmConnectDialogLabels.message"
+      :ok-label="confirmConnectDialogLabels.ok"
+      :cancel-label="confirmConnectDialogLabels.cancel"
+      @ok="confirmConnect" />
+  </div>
 </template>
 
 <script>
@@ -101,11 +110,20 @@ export default {
   data: () => ({
     connectionInProgress: false,
     errorMessage: '',
+    selectedConnector: null
   }),
   computed: {
     enabledConnectors() {
       return this.connectors && this.connectors.slice().filter(connector => connector.enabled) || [];
-    }
+    },
+    confirmConnectDialogLabels() {
+      return {
+        title: this.$t('agenda.confirmConnectDialog.title'),
+        message: this.$t('agenda.confirmConnectDialog.message'),
+        ok: this.$t('agenda.confirmConnectDialog.okButton'),
+        cancel: this.$t('agenda.confirmConnectDialog.cancelButton')
+      };
+    },
   },
   created() {
     this.$root.$on('agenda-connectors-drawer-open', this.open);
@@ -133,7 +151,16 @@ export default {
     },
     connect(connector) {
       this.connectionInProgress = true;
-      this.$root.$emit('agenda-connector-connect', connector);
+      this.selectedConnector = connector;
+      if (this.enabledConnectors.some(connector => connector.isSignedIn && connector.user)) {
+        this.$refs.confirmConnectDialog.open();
+      }
+      else {
+        this.confirmConnect();
+      }
+    },
+    confirmConnect() {
+      this.$root.$emit('agenda-connector-connect', this.selectedConnector);
     },
     disconnect(connector) {
       this.connectionInProgress = true;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
@@ -118,10 +118,10 @@ export default {
     },
     confirmConnectDialogLabels() {
       return {
-        title: this.$t('agenda.confirmConnectDialog.title'),
-        message: this.$t('agenda.confirmConnectDialog.message'),
-        ok: this.$t('agenda.confirmConnectDialog.okButton'),
-        cancel: this.$t('agenda.confirmConnectDialog.cancelButton')
+        title: this.$t('agenda.agendaConnectors.confirmConnectDialog.title'),
+        message: this.$t('agenda.agendaConnectors.confirmConnectDialog.message'),
+        ok: this.$t('agenda.agendaConnectors.confirmConnectDialog.ok'),
+        cancel: this.$t('agenda.agendaConnectors.confirmConnectDialog.cancel')
       };
     },
   },
@@ -152,7 +152,7 @@ export default {
     connect(connector) {
       this.connectionInProgress = true;
       this.selectedConnector = connector;
-      if (this.enabledConnectors.some(connector => connector.isSignedIn && connector.user)) {
+      if (this.enabledConnectors.some(c => c.isSignedIn && c.user)) {
         this.$refs.confirmConnectDialog.open();
       }
       else {


### PR DESCRIPTION
Prior to these changes, when I'm already connected to a personal agenda with an agenda connector and I want to switch the connection to another connector, the current connected personal agenda will be disconnected automatically without any confirmation. 
After this commit, in order to avoid any bad intention, instead of the automatic disconnection, we will display a confirmation popup alerting that the already connected agenda will be closed.