### PR TITLE
Task-55923: Add missing gamification properties path to agenda translations properties.

### DIFF
--- a/agenda-webapps/src/main/resources/locale/addon/Gamification_fr.properties
+++ b/agenda-webapps/src/main/resources/locale/addon/Gamification_fr.properties
@@ -1,0 +1,13 @@
+exoplatform.gamification.gamificationinformation.rule.title.CreateEvent=Agenda : Créer un événement 
+exoplatform.gamification.gamificationinformation.rule.description.def_CreateEvent=Vous avez créé un événement
+
+exoplatform.gamification.gamificationinformation.rule.title.UpdateEvent=Agenda : Mettre à jour un événement
+exoplatform.gamification.gamificationinformation.rule.description.def_UpdateEvent=Vous avez mis à jour un événement
+exoplatform.gamification.gamificationinformation.rule.title.ReplyToEvent=Agenda : Répondre à un événement
+exoplatform.gamification.gamificationinformation.rule.description.def_ReplyToEvent=Vous avez répondu à un événement auquel vous êtes invité
+
+exoplatform.gamification.gamificationinformation.rule.title.CreateDatePoll=Agenda : Créer un sondage par date
+exoplatform.gamification.gamificationinformation.rule.description.def_CreateDatePoll=Vous avez créé un sondage par date
+
+exoplatform.gamification.gamificationinformation.rule.title.VoteDatePoll=Agenda : Voter dans un sondage par date
+exoplatform.gamification.gamificationinformation.rule.description.def_VoteDatePoll=Vous avez voté dans un sondage par date

--- a/translations.properties
+++ b/translations.properties
@@ -27,3 +27,4 @@ Agenda.properties=agenda-webapps/src/main/resources/locale/portlet/Agenda_en.pro
 Portlets.properties=agenda-webapps/src/main/resources/locale/portlet/Portlets_en.properties
 AgendaNotification.properties=agenda-webapps/src/main/resources/locale/notification/AgendaNotification_en.properties
 Analytics.properties=agenda-webapps/src/main/resources/locale/portlet/Analytics_en.properties
+Gamification.properties=agenda-webapps/src/main/resources/locale/addon/Gamification_en.properties


### PR DESCRIPTION
ISSUE : in gamification earn points some inputs of agenda rules are displayed in English when user change the language to french.
FIX : add gamification properties to translations properties in agenda module .