### PR TITLE
Task-58171: Remove agendaConnectors module dependency from agenda

### DIFF
--- a/agenda-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -74,9 +74,6 @@
         <module>AgendaCommon</module>
       </depends>
       <depends>
-        <module>agendaConnectors</module>
-      </depends>
-      <depends>
         <module>commonVueComponents</module>
       </depends>
       <depends>
@@ -174,9 +171,6 @@
       <module>iePolyfills</module>
     </depends>
     <depends>
-      <module>agendaConnectors</module>
-    </depends>
-    <depends>
       <module>commons-cometd3</module>
       <as>cCometd</as>
     </depends>
@@ -234,9 +228,6 @@
       </depends>
       <depends>
         <module>extensionRegistry</module>
-      </depends>
-      <depends>
-        <module>agendaConnectors</module>
       </depends>
       <depends>
         <module>AgendaCommon</module>


### PR DESCRIPTION
Prior to these changes, agenda depends from agendaConnectors module which is implemented in agenda-connectors addon codebase.
After this commit, agendaConnectors module dependency will be removed from agenda codebase since agenda connectors extensions will be registered from agenda-connector addon codebase into agenda portlet.