### PR TITLE
Task-57950: Retrieve events of only current connected connector

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDates.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDates.vue
@@ -195,7 +195,7 @@ export default {
       return `top: ${this.currentTimeTop}px;`;
     },
     connectedConnector() {
-      return this.connectors.find(connector => connector.isSignedIn);
+      return this.connectors.find(connector => connector.connected);
     },
     connectedConnectorAvatar() {
       return this.connectedConnector && this.connectedConnector.avatar || '';


### PR DESCRIPTION
Priori to this change, we retrieve events of only signed in connectors which causes problems with not oauth connectors. After this commit, we will retrieve events of only current connected connector.