### PR TITLE
Task-59121: Delete event in Personal exchange agenda

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventServiceImpl.java
@@ -754,6 +754,7 @@ public class AgendaEventServiceImpl implements AgendaEventService {
       throw new IllegalAccessException("User " + userIdentityId + " hasn't enough privileges to delete event with id " + eventId);
     }
     EventAttendeeList eventAttendeeList = attendeeService.getEventAttendees(event.getId());
+    Utils.broadcastEvent(listenerService, Utils.PRE_DELETE_AGENDA_EVENT_EVENT, event.getId(), userIdentityId);
 
     agendaEventStorage.deleteEventById(eventId);
 

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -64,6 +64,8 @@ public class Utils {
 
   public static final String            POST_DELETE_AGENDA_EVENT_EVENT = "exo.agenda.event.deleted";
 
+  public static final String            PRE_DELETE_AGENDA_EVENT_EVENT = "exo.agenda.event.pre.deleted";
+
   public static final String            POST_EVENT_RESPONSE_SENT       = "exo.agenda.event.responseSent";
 
   public static final String            POST_EVENT_RESPONSE_SAVED      = "exo.agenda.event.responseSaved";


### PR DESCRIPTION
After these changes, we can delete the remote event from the personal exchange calendar of all participants of the event.