### PR TITLE
TASK-59178: Use PATCH annotation from Meeds WS implementation

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/rest/AgendaEventRest.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/rest/AgendaEventRest.java
@@ -54,7 +54,7 @@ import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvide
 import org.exoplatform.social.core.manager.IdentityManager;
 
 import io.swagger.annotations.*;
-import io.swagger.jaxrs.PATCH;
+import org.exoplatform.services.rest.http.PATCH;
 
 @Path("/v1/agenda/events")
 @Api(value = "/v1/agenda/events", description = "Manages agenda events associated to users and spaces") // NOSONAR

--- a/agenda-services/src/main/java/org/exoplatform/agenda/rest/AgendaSettingsRest.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/rest/AgendaSettingsRest.java
@@ -22,7 +22,7 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 
 import io.swagger.annotations.*;
-import io.swagger.jaxrs.PATCH;
+import org.exoplatform.services.rest.http.PATCH;
 
 @Path("/v1/agenda/settings")
 @Api(value = "/v1/agenda/settings", description = "Manages agenda settings associated to users") // NOSONAR


### PR DESCRIPTION
Prior to this change, Endpoints with http patch requests are using the swagger jaxrs PATCH annotation,
This PR should use the PATCH annotation from Meeds WS implementation instead of swagger jaxrs annotation