### PR TITLE
fix: Fix reply to an invitation to a recurring event for which the first occurrence is past event - EXO-46906

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/RestUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/RestUtils.java
@@ -198,7 +198,13 @@ public class RestUtils {
                                                 List<String> expandProperties) throws IllegalAccessException {
     Event event = agendaEventService.getEventById(eventId, userTimeZone, identityId);
     if (event.getRecurrence() != null && firstOccurrence) {
-      List<Event> occurrences = Utils.getOccurrences(event, event.getStart().minusDays(1).toLocalDate(), null, 1);
+      List<Event> occurrences = null;
+      LocalTime time = event.getStart().toLocalTime();
+      if (time.isAfter(ZonedDateTime.now().toLocalTime())){
+        occurrences = Utils.getOccurrences(event, LocalDate.from(ZonedDateTime.now()), null, 1);
+      } else {
+        occurrences = Utils.getOccurrences(event, LocalDate.from(ZonedDateTime.now()).plusDays(1), null, 1);
+      }
       if (CollectionUtils.isNotEmpty(occurrences)) {
         event = occurrences.get(0);
         occurrenceId = event.getOccurrence().getId();

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/RestUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/RestUtils.java
@@ -198,13 +198,8 @@ public class RestUtils {
                                                 List<String> expandProperties) throws IllegalAccessException {
     Event event = agendaEventService.getEventById(eventId, userTimeZone, identityId);
     if (event.getRecurrence() != null && firstOccurrence) {
-      List<Event> occurrences = null;
-      LocalTime time = event.getStart().toLocalTime();
-      if (time.isAfter(ZonedDateTime.now().toLocalTime())){
-        occurrences = Utils.getOccurrences(event, LocalDate.from(ZonedDateTime.now()), null, 1);
-      } else {
-        occurrences = Utils.getOccurrences(event, LocalDate.from(ZonedDateTime.now()).plusDays(1), null, 1);
-      }
+      LocalDate occurrencesFromDate = event.getStart().toLocalTime().isAfter(ZonedDateTime.now().toLocalTime()) ? LocalDate.from(ZonedDateTime.now()) : LocalDate.from(ZonedDateTime.now()).plusDays(1);
+      List<Event> occurrences = Utils.getOccurrences(event, occurrencesFromDate, null, 1);
       if (CollectionUtils.isNotEmpty(occurrences)) {
         event = occurrences.get(0);
         occurrenceId = event.getOccurrence().getId();


### PR DESCRIPTION
Prior to this change, we can't reply to an invitation to a recurring event for which the first occurrence is a past event. After this fix, we will be able to reply to the next occurrence net yet started of any recurrent event already started in the past. 