### PR TITLE
fix: Fix no notification received for weekly events - EXO-60311

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -681,21 +681,12 @@ public class NotificationUtils {
             return "Each " + eventRecurrence.getInterval() + "days";
           }
         case "WEEKLY":
-          if (eventRecurrence.getInterval() == 1 && event.getRecurrence().getByDay().size() == 1) {
-            String dayNumber = eventRecurrence.getByDay().get(0);
-            DayOfWeek dayName = DayOfWeek.of(Integer.parseInt(dayNumber));
-            return "Weekly on " + StringUtils.lowerCase(String.valueOf(dayName)) + "";
-          } else if (eventRecurrence.getInterval() == 1 && eventRecurrence.getByDay().size() > 1) {
+          if (eventRecurrence.getInterval() == 1) {
             List<String> dayNamesAbbreviations = eventRecurrence.getByDay();
             return "Weekly on " + AgendaDateUtils.getDayNameFromDayAbbreviation(dayNamesAbbreviations);
-          } else if (eventRecurrence.getByDay().size() == 1) {
-            String dayNumber = eventRecurrence.getByDay().get(0);
-            DayOfWeek dayName = DayOfWeek.of(Integer.parseInt(dayNumber));
-            return "Each Week " + eventRecurrence.getInterval() + " on " + StringUtils.lowerCase(String.valueOf(dayName));
           } else {
             List<String> dayNamesAbbreviations = eventRecurrence.getByDay();
-            return "Each Week " + eventRecurrence.getInterval() + " on "
-                + AgendaDateUtils.getDayNameFromDayAbbreviation(dayNamesAbbreviations);
+            return "Each Week " + eventRecurrence.getInterval() + " on " + AgendaDateUtils.getDayNameFromDayAbbreviation(dayNamesAbbreviations);
           }
         case "MONTHLY":
           if (eventRecurrence.getInterval() == 1) {


### PR DESCRIPTION
Prior to this change, when we create a recurring weekly event on specific day, no notification is received by the invited user. The problem is that it is not possible to get the name of the recurring day by the its number, so we have fixed that by getting the day names by abbreviation.