### PR TITLE
fix:Agenda :Event from last month of January to any date of February is displayed on all the month EXO-61629

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDatePickers.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDatePickers.vue
@@ -124,8 +124,8 @@ export default {
       const date = this.$agendaUtils.toDate(this.endDate);
       const newDate = this.$agendaUtils.toDate(this.event.endDate);
       newDate.setFullYear(date.getFullYear());
-      newDate.setMonth(date.getMonth());
       newDate.setDate(date.getDate());
+      newDate.setMonth(date.getMonth());
       this.event.endDate = newDate;
       this.event.end = this.$agendaUtils.toRFC3339(this.event.endDate);
       this.duration = newDate.getTime() - this.$agendaUtils.toDate(this.event.startDate).getTime();


### PR DESCRIPTION
 Prior to this change, when Created an all day event from 31 January to any date of February, The event is displayed on the whole month of February until the 1st of march. After this change, The event displayed correctly.