### PR TITLE
fix: Can't invite user to an event by email if '-' character exists in the email's domain name - EXO-61732

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
@@ -161,7 +161,7 @@ export default {
       }
     },
     saveGuestEmail() {
-      const reg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}])|(([\w]+\.)+[a-zA-Z]{2,24}))$/;
+      const reg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,24}))$/;
       const input = this.$refs.invitedAttendeeAutoComplete.searchTerm;
       const words = input!== null ? input.split(' ') : '';
       const email = words[words.length - 1];


### PR DESCRIPTION
prior to this change, we can't invite a user to an event by email if the '-' character exists in the email's domain name after this change, the invitation is sent to user with an email that contains '-'

(cherry picked from commit 5f0d38e0f5a3ccc96caf596863eb5678b8316d7a)