### PR TITLE
fix: drawer is not displayed when inside a sticky container - EXO-62633

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -127,10 +127,18 @@ export default {
 
     this.spaceId = eXo.env.portal.spaceId;
 
+    document.addEventListener('drawerOpened', () => this.$el.closest('#stickyBlockDesktop').style.position = 'static');
+    document.addEventListener('drawerClosed', () => this.$el.closest('#stickyBlockDesktop').style.position = 'sticky');
+
     // Asynchronously load settings to use it in dialogs,
     // not needed for main screen display
     this.initSettings();
   },
+  beforeDestroy() {
+    document.removeEventListener('drawerOpened', () => this.$el.closest('#stickyBlockDesktop').style.position = 'static');
+    document.removeEventListener('drawerClosed', () => this.$el.closest('#stickyBlockDesktop').style.position = 'sticky');
+  },
+
   methods: {
     initSettings(userSettings) {
       if (userSettings) {


### PR DESCRIPTION
When the drawer parent is inside a container with position: sticky , it is always displayed under the overlay and we can not interact with it. The fix changes the CSS propery position when the drawer is opened and restores it to the initial value once closed.