### PR TITLE
fix: remove the extra margins so the notification blocks will be aligned  - EXO-62228 (#533)

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserSettings.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/components/AgendaUserSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app v-if="displayed">
-    <v-card class="ma-4 border-radius" flat>
+    <v-card class="my-4 border-radius" flat>
       <v-list two-line>
         <agenda-user-general-settings :settings="settings" />
         <agenda-user-connector-settings :settings="settings" />


### PR DESCRIPTION
this fix is added to remove the extra margins in agenda settings block so the settings blocks will be aligned