### PR TITLE
fix: wrong recurrence day selected when updating an event by D&D - EXO-63851

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "java.compile.nullAnalysis.mode": "disabled"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.compile.nullAnalysis.mode": "disabled"
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/rest/AgendaEventRest.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/rest/AgendaEventRest.java
@@ -300,7 +300,7 @@ public class AgendaEventRest implements ResourceContainer, Startable {
           cleanupAttachedEntitiesIds(eventEntity);
         }
         return eventEntity;
-      }).filter(eventEntity -> eventEntity != null).collect(Collectors.toList());
+      }).filter(Objects::nonNull).toList();
 
       EventList eventList = new EventList();
       eventList.setEvents(eventEntities);

--- a/agenda-webapps/package-lock.json
+++ b/agenda-webapps/package-lock.json
@@ -5055,9 +5055,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -497,8 +497,9 @@ export default {
 
           // when this is about a recurrent event
           // and the event is an all day event,
-          // when moving event, it shouldn't
-          const ignoreRecurrentPopin = event.allDay;
+          // or the event is in custom recurrence type
+          // when moving event, it shouldn't show the popin
+          const ignoreRecurrentPopin = event.allDay || event.parent.recurrence.type === 'CUSTOM';
           const changeDatesOnly = true;
           this.$root.$emit('agenda-event-save', event, ignoreRecurrentPopin, changeDatesOnly);
         });

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -107,7 +107,6 @@ export default {
               .then(() => {
                 recurrentEvent.start = this.event.start;
                 recurrentEvent.end = this.event.end;
-                const day = this.event.start;
                 const eventRecurrence = this.event && this.event.recurrence || this.event.parent && this.event.parent.recurrence;
                 const recurrenceType = eventRecurrence && eventRecurrence.type || 'NO_REPEAT';
                 if (recurrenceType === 'WEEKLY') {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -114,7 +114,6 @@ export default {
                   const dayNameFromDate  = this.$agendaUtils.getDayNameFromDate(this.event.start);
                   recurrentEvent.recurrence.byDay = [dayNameFromDate.substring(0, 2).toUpperCase()];
                 }
-                this.$agendaUtils.getDayNameFromDate(day, eXo.env.portal.language);
                 delete recurrentEvent.id;
                 return this.$eventService.createEvent(recurrentEvent);
               })

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -107,6 +107,14 @@ export default {
               .then(() => {
                 recurrentEvent.start = this.event.start;
                 recurrentEvent.end = this.event.end;
+                const day = this.event.start;
+                const eventRecurrence = this.event && this.event.recurrence || this.event.parent && this.event.parent.recurrence;
+                const recurrenceType = eventRecurrence && eventRecurrence.type || 'NO_REPEAT';
+                if (recurrenceType === 'WEEKLY') {
+                  const dayNameFromDate  = this.$agendaUtils.getDayNameFromDate(this.event.start);
+                  recurrentEvent.recurrence.byDay = [dayNameFromDate.substring(0, 2).toUpperCase()];
+                }
+                this.$agendaUtils.getDayNameFromDate(day, eXo.env.portal.language);
                 delete recurrentEvent.id;
                 return this.$eventService.createEvent(recurrentEvent);
               })


### PR DESCRIPTION
When dragging & dropping a recurrent event, it does not update the recurrence day and leads to unusual behavior: the recurrence is still on the same day as the original event.
The fix updates the recurrence object with the correct day and disables displaying the update popin to not update events with custom recurrence as it is not possible to predict the updates of days with drag & drop 