### PR TITLE
fix: wrong time selected when updating an event by D&D - EXO-63851

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -113,8 +113,17 @@ export default {
                 recurrentEvent.description = this.event.description;
                 recurrentEvent.location = this.event.location;
                 recurrentEvent.summary = this.event.summary;
+                if (this.event.recurrence) {
+                  recurrentEvent.recurrence = this.event.recurrence;
+                } else {
+                  const eventRecurrence = this.event && this.event.recurrence || this.event.parent && this.event.parent.recurrence;
+                  const recurrenceType = eventRecurrence && eventRecurrence.type || 'NO_REPEAT';
+                  if (recurrenceType === 'WEEKLY') {
+                    const dayNameFromDate = this.$agendaUtils.getDayNameFromDate(this.event.start);
+                    recurrentEvent.recurrence.byDay = [dayNameFromDate.substring(0, 2).toUpperCase()];
+                  }
 
-                recurrentEvent.recurrence = this.event.recurrence;
+                }
                 delete recurrentEvent.id;
                 return this.$eventService.createEvent(recurrentEvent);
               })

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -116,8 +116,8 @@ export default {
                 if (this.event.recurrence) {
                   recurrentEvent.recurrence = this.event.recurrence;
                 } else {
-                  const eventRecurrence = this.event && this.event.recurrence || this.event.parent && this.event.parent.recurrence;
-                  const recurrenceType = eventRecurrence && eventRecurrence.type || 'NO_REPEAT';
+                  const eventRecurrence = this.event?.recurrence || this.event?.parent?.recurrence;
+                  const recurrenceType = eventRecurrence?.type || 'NO_REPEAT';
                   if (recurrenceType === 'WEEKLY') {
                     const dayNameFromDate = this.$agendaUtils.getDayNameFromDate(this.event.start);
                     recurrentEvent.recurrence.byDay = [dayNameFromDate.substring(0, 2).toUpperCase()];


### PR DESCRIPTION
This fix will be appended to the previous ones to cover all event's changing in case of drag & drop or in case of editing the event using the drawer