### PR TITLE
fix: Remove the use secret key in agenda connectors in the front side - EXO-65042

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/connector/AgendaConnector.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/connector/AgendaConnector.vue
@@ -56,7 +56,6 @@ export default {
             const connectorObj = this.remoteProviders.find(connectorSettings => connectorSettings.name === connector.name);
             connector.enabled = connectorObj && connectorObj.enabled || false;
             connector.apiKey = connectorObj && connectorObj.apiKey || '';
-            connector.secretKey = connectorObj && connectorObj.secretKey || '';
             connector.connected = connector.enabled && this.settings.connectedRemoteProvider === connectorObj.name;
             connector.user = connector.connected && this.settings.connectedRemoteUserId || '';
           });
@@ -72,7 +71,7 @@ export default {
       this.connectors
         .forEach(connector => {
           if (connector.init && !connector.initialized && connector.enabled && connector.apiKey) {
-            connector.init(this.connectionStatusChanged, this.connectionLoading, connector.apiKey, connector.secretKey);
+            connector.init(this.connectionStatusChanged, this.connectionLoading, connector.apiKey);
           }
         });
     },


### PR DESCRIPTION
Prior to this change, the secert key was needed to be able to use the google api, in the first implementation the seceret_key was exposed in front side in js files which is considered as a security issue.
This PR hide an remove any use of the secret_key in connector initialization