### PR TITLE
fix : Dispaly all day events planned for the current day on the agenda gadget in space stream page - EXO-65143

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
@@ -137,7 +137,7 @@ export default {
 
         let periodStartDate = new Date(this.periodStartDate);
         periodStartDate = new Date(periodStartDate.getFullYear(), periodStartDate.getMonth(), periodStartDate.getDate());
-        if (new Date(eventStartDate.startDate).getTime() > new Date(periodStartDate).getTime()) {
+        if (new Date(eventStartDate.startDate).getTime() > new Date(periodStartDate).getTime() || (new Date(eventStartDate.startDate).getTime() === new Date(periodStartDate).getTime() && event.allDay)) {
           count = this.addEventByDateInMap(eventStartDate, event.startDate, eventsByDates, count);
         }
 


### PR DESCRIPTION
This change is going to Display all-day events planned for the current day on the agenda gadget in the Space Stream page