### PR TITLE
fix : drag and drop extend event - EXO-65674

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -503,7 +503,7 @@ export default {
           // and the event is an all day event,
           // or the event is in custom recurrence type
           // when moving event, it shouldn't show the popin
-          const ignoreRecurrentPopin = event.allDay || event.parent.recurrence.type === 'CUSTOM';
+          const ignoreRecurrentPopin = event.allDay || event.parent?.recurrence.type === 'CUSTOM';
           const changeDatesOnly = true;
           this.$root.$emit('agenda-event-save', event, ignoreRecurrentPopin, changeDatesOnly);
         });


### PR DESCRIPTION
Before this change, we were unable to drag and drop an extended event, and a console error was displayed with the message Cannot read properties of null (reading 'recurrence').
This change handles this error.