### PR TITLE
fix : Remove the event reminder from the parent event to avoid redundancy at the first occurrence - EXO-65965

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventReminderComputingListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventReminderComputingListener.java
@@ -48,6 +48,8 @@ public class AgendaEventReminderComputingListener extends Listener<AgendaEventMo
         ZonedDateTime occurrenceId = occurrence.getOccurrence().getId();
         getAgendaEventService().saveEventExceptionalOccurrence(eventId, occurrenceId);
       }
+      //Remove the event reminder from the parent event to avoid redundancy at the first occurrence
+      getAgendaEventReminderService().removeEventReminders(eventId);
     }
   }
 


### PR DESCRIPTION
Before this change, when we created a recurring event on the current day, users would receive two reminder notifications at the same time. Additionally, even if we removed the first occurrence (the first event on the event's creation day), users would still receive a reminder notification, even though it's well deleted. This issue was due to the reminder of the parent event.

With this change, we will remove the parent event's reminder if the event is recurrent, in order to avoid redundancy during the first occurrence.