### PR TITLE
fix : Prevent to send the reminder notification of the parent recurrent event to avoid the redundancy at the first occurrence -EXO-65965 (#572)

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
@@ -223,7 +223,11 @@ public class AgendaEventReminderServiceImpl implements AgendaEventReminderServic
 
     List<EventReminder> reminders = reminderStorage.getEventReminders(currentMinute, endCurrentMinute);
     for (EventReminder eventReminder : reminders) {
-      sendReminderNotification(eventReminder);
+      Event event = eventStorage.getEventById(eventReminder.getEventId());
+      // do not send a reminder notification of the Recurrent parent event.
+      if (event.getRecurrence() == null) {
+        sendReminderNotification(eventReminder);
+      }
     }
   }
 

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
@@ -22,10 +22,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import org.exoplatform.commons.api.notification.service.WebNotificationService;
 import org.junit.Test;
 
 import org.exoplatform.agenda.constant.*;
 import org.exoplatform.agenda.model.*;
+
 
 public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
 
@@ -382,6 +384,74 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
 
     eventReminders = agendaEventReminderService.getEventReminders(eventId, user4IdentityId);
     assertEquals(0, eventReminders.size());
+  }
+
+  @Test
+  public void sendRemindersTest() throws Exception {
+    ZonedDateTime start = ZonedDateTime.now().withNano(0).plusMinutes(1);
+    ZonedDateTime end = start.plusMinutes(15);
+    boolean allDay = false;
+    long userIdentityId = Long.parseLong(testuser1Identity.getId());
+    WebNotificationService webNotificationService = container.getComponentInstanceOfType(WebNotificationService.class);
+
+    Event reccurrentEvent = newEventInstance(start, end, allDay);
+    EventRecurrence recurrence = new EventRecurrence(0,
+            start.plusDays(2).toLocalDate(),
+            0,
+            EventRecurrenceType.DAILY,
+            EventRecurrenceFrequency.DAILY,
+            1,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    reccurrentEvent.setRecurrence(recurrence);
+
+    reccurrentEvent = createEvent(reccurrentEvent.clone(), Long.parseLong(testuser1Identity.getId()), testuser1Identity, testuser2Identity);
+
+    long recEventId = reccurrentEvent.getId();
+
+    agendaEventService.saveEventExceptionalOccurrence(recEventId, start);
+    agendaEventService.saveEventExceptionalOccurrence(recEventId, start.plusDays(1));
+    List<Event> exceptionalOccurrence =  agendaEventService.getExceptionalOccurrenceEvents(recEventId, TimeZone.getTimeZone("Tunisia").toZoneId() , userIdentityId);
+
+    assertNotNull(exceptionalOccurrence);
+    long firstExceptionalOccurrenceId = exceptionalOccurrence.get(0).getId();
+    List<EventReminder>  eventReminders = agendaEventReminderService.getEventReminders(recEventId, userIdentityId);
+    assertNotNull(eventReminders);
+    assertEquals(1, eventReminders.size());
+
+    List<EventReminder> exceptionalOccurrenceReminders = agendaEventReminderService.getEventReminders(firstExceptionalOccurrenceId,
+            userIdentityId);
+    assertNotNull(exceptionalOccurrenceReminders);
+    assertEquals(1, exceptionalOccurrenceReminders.size());
+    webNotificationService.resetNumberOnBadge(testuser1Identity.getRemoteId());
+    agendaEventReminderService.sendReminders();
+    // Assert receive only one reminder notification of the first recurrence.
+    int notificationSize  = webNotificationService.getNumberOnBadge(testuser1Identity.getRemoteId());
+    assertEquals(1, notificationSize);
+    webNotificationService.resetNumberOnBadge(testuser1Identity.getRemoteId());
+
+    //
+    Event event = newEventInstance(start, start, allDay);
+    event.setRecurrence(null);
+    event = createEvent(event.clone(), Long.parseLong(testuser1Identity.getId()), testuser1Identity);
+    long eventId = event.getId();
+    eventReminders = agendaEventReminderService.getEventReminders(eventId, userIdentityId);
+    assertNotNull(eventReminders);
+    assertEquals(1, eventReminders.size());
+    EventReminder eventReminder = eventReminders.get(0);
+    assertNotNull(eventReminder);
+    agendaEventReminderService.sendReminders();
+    // Assert receiving the reminder notification for the non-recurring event.
+    assertEquals(notificationSize + 1, webNotificationService.getNumberOnBadge(testuser1Identity.getRemoteId()));
   }
 
 }

--- a/agenda-services/src/test/resources/conf/exo.agenda.service-configuration.xml
+++ b/agenda-services/src/test/resources/conf/exo.agenda.service-configuration.xml
@@ -257,6 +257,47 @@
         </object-param>
       </init-params>
     </component-plugin>
+
+    <!--  EventReminderNotificationPlugin -->
+    <component-plugin>
+      <name>notification.plugins</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.agenda.notification.plugin.EventReminderNotificationPlugin</type>
+      <init-params>
+        <value-param>
+          <name>agenda.notification.plugin.key</name>
+          <value>EventReminderNotificationPlugin</value>
+        </value-param>
+        <object-param>
+          <name>template.EventReminderNotificationPlugin</name>
+          <description>The template of EventReminderNotificationPlugin</description>
+          <object type="org.exoplatform.commons.api.notification.plugin.config.PluginConfig">
+            <field name="pluginId">
+              <string>EventReminderNotificationPlugin</string>
+            </field>
+            <field name="resourceBundleKey">
+              <string>UINotification.label.EventReminderNotificationPlugin</string>
+            </field>
+            <field name="order">
+              <string>6</string>
+            </field>
+            <field name="defaultConfig">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>Instantly</string>
+                </value>
+              </collection>
+            </field>
+            <field name="groupId">
+              <string>agenda</string>
+            </field>
+            <field name="bundlePath">
+              <string>locale.notification.AgendaNotification</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION

Before this change, when we created a recurring event on the current day, users would receive two reminder notifications at the same time. Additionally, even if we removed the first occurrence (the first event on the event's creation day), users would still receive a reminder notification, even though it's well deleted. This issue was due to the reminder of the parent event.

With this change, we will prevent to send the parent event's reminder if the event is recurrent, in order to avoid redundancy during the first occurrence.