### PR TITLE
fix: Add a default time zone to resolve the build failure in the unit tests - EXO-66210

### DIFF
--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
@@ -388,6 +388,7 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
 
   @Test
   public void sendRemindersTest() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("Tunisia"));
     ZonedDateTime start = ZonedDateTime.now().withNano(0).plusMinutes(1);
     ZonedDateTime end = start.plusMinutes(15);
     boolean allDay = false;


### PR DESCRIPTION
This change is going to add a default time zone to the  sendRemindersTest method to resolve the build failure in the unit tests .