### PR TITLE
feat: Modify agenda notification to rely on mute space feature - EXO-66729

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -741,6 +741,7 @@ public class NotificationUtils {
     } else {
       if (SpaceIdentityProvider.NAME.equals(identity.getProviderId())) {
         Space space = spaceService.getSpaceByPrettyName(identity.getRemoteId());
+        notification.setSpaceId(Long.parseLong(space.getId()));
         avatarUrl = LinkProviderUtils.getSpaceAvatarUrl(space);
       } else {
         avatarUrl = LinkProviderUtils.getUserAvatarUrl(identity.getProfile());

--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/notification-configuration.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/notification-configuration.xml
@@ -67,6 +67,9 @@
               <field name="bundlePath">
                 <string>locale.notification.AgendaNotification</string>
               </field>
+              <field name="mutable">
+                <boolean>false</boolean>
+              </field>
             </object>
           </object-param>
       </init-params>
@@ -107,6 +110,9 @@
             </field>
             <field name="bundlePath">
               <string>locale.notification.AgendaNotification</string>
+            </field>
+            <field name="mutable">
+              <boolean>false</boolean>
             </field>
           </object>
         </object-param>
@@ -149,6 +155,9 @@
             <field name="bundlePath">
               <string>locale.notification.AgendaNotification</string>
             </field>
+            <field name="mutable">
+              <boolean>false</boolean>
+            </field>
           </object>
         </object-param>
       </init-params>
@@ -189,6 +198,9 @@
             </field>
             <field name="bundlePath">
               <string>locale.notification.AgendaNotification</string>
+            </field>
+            <field name="mutable">
+              <boolean>false</boolean>
             </field>
           </object>
         </object-param>
@@ -231,6 +243,9 @@
             <field name="bundlePath">
               <string>locale.notification.AgendaNotification</string>
             </field>
+            <field name="mutable">
+              <boolean>false</boolean>
+            </field>
           </object>
         </object-param>
       </init-params>
@@ -272,6 +287,9 @@
             <field name="bundlePath">
               <string>locale.notification.AgendaNotification</string>
             </field>
+            <field name="mutable">
+              <boolean>false</boolean>
+            </field>
           </object>
         </object-param>
       </init-params>
@@ -312,6 +330,9 @@
             </field>
             <field name="bundlePath">
               <string>locale.notification.AgendaNotification</string>
+            </field>
+            <field name="mutable">
+              <boolean>false</boolean>
             </field>
           </object>
         </object-param>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/AgendaEventPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/AgendaEventPlugin.vue
@@ -50,11 +50,15 @@ export default {
     },
   },
   created() {
-    this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
-      if (identity?.space) {
-        this.space = identity.space;
-      }
-    });
+    if (this.notification?.space) {
+      this.space = this.notification?.space;
+    } else {
+      this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
+        if (identity?.space) {
+          this.space = identity.space;
+        }
+      });
+    }
   },
   computed: {
     eventUrl() {
@@ -67,7 +71,7 @@ export default {
       return this.space?.avatarUrl;
     },
     spaceName() {
-      return this.space?.prettyName;
+      return this.space?.displayName;
     },
     message() {
       const eventTitle = this.notification?.parameters?.eventTitle;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/DatePollPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/DatePollPlugin.vue
@@ -50,11 +50,15 @@ export default {
     },
   },
   created() {
-    this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
-      if (identity?.space) {
-        this.space = identity.space;
-      }
-    });
+    if (this.notification?.space) {
+      this.space = this.notification?.space;
+    } else {
+      this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
+        if (identity?.space) {
+          this.space = identity.space;
+        }
+      });
+    }
   },
   computed: {
     eventUrl() {
@@ -67,7 +71,7 @@ export default {
       return this.space?.avatarUrl;
     },
     spaceName() {
-      return this.space?.prettyName;
+      return this.space?.displayName;
     },
     message() {
       const eventTitle = this.notification?.parameters?.eventTitle;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReminderPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReminderPlugin.vue
@@ -53,11 +53,15 @@ export default {
     },
   },
   created() {
-    this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
-      if (identity?.space) {
-        this.space = identity.space;
-      }
-    });
+    if (this.notification?.space) {
+      this.space = this.notification?.space;
+    } else {
+      this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
+        if (identity?.space) {
+          this.space = identity.space;
+        }
+      });
+    }
   },
   computed: {
     eventUrl() {
@@ -67,7 +71,7 @@ export default {
       return this.space?.avatarUrl;
     },
     spaceName() {
-      return this.space?.prettyName;
+      return this.space?.displayName;
     },
     eventTitle() {
       return this.notification?.parameters?.eventTitle;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReplyPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReplyPlugin.vue
@@ -50,11 +50,15 @@ export default {
     },
   },
   created() {
-    this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
-      if (identity?.space) {
-        this.space = identity.space;
-      }
-    });
+    if (this.notification?.space) {
+      this.space = this.notification?.space;
+    } else {
+      this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
+        if (identity?.space) {
+          this.space = identity.space;
+        }
+      });
+    }
   },
   computed: {
     eventUrl() {
@@ -67,7 +71,7 @@ export default {
       return this.notification?.parameters?.participantAvatarUrl;
     },
     spaceName() {
-      return this.space?.prettyName;
+      return this.space?.displayName;
     },
     message() {
       const eventTitle = this.notification?.parameters?.eventTitle;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/PollVotePlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/PollVotePlugin.vue
@@ -50,11 +50,15 @@ export default {
     },
   },
   created() {
-    this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
-      if (identity?.space) {
-        this.space = identity.space;
-      }
-    });
+    if (this.notification?.space) {
+      this.space = this.notification?.space;
+    } else {
+      this.$identityService.getIdentityById(this.notification?.parameters?.ownerId).then(identity => {
+        if (identity?.space) {
+          this.space = identity.space;
+        }
+      });
+    }
   },
   computed: {
     eventUrl() {
@@ -67,7 +71,7 @@ export default {
       return this.space?.avatarUrl;
     },
     spaceName() {
-      return this.space?.prettyName;
+      return this.space?.displayName;
     },
     message() {
       const eventTitle = this.notification?.parameters?.eventTitle;


### PR DESCRIPTION
Before this fix, the agenda notification does not rely on the framework to mute spaces. This commit add this feature, and configure correctly agenda notification : none of them can be muted as user is always part of the event when he receive such notification.