### PR TITLE
feat: Modify agenda notification to align the button style with meeds - EXO-66916

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/AgendaEventPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/AgendaEventPlugin.vue
@@ -29,10 +29,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div v-if="buttonText!=''" class="mt-1">
         <v-btn
-          class="btn primary px-2"
-          outlined
-          small>
-          {{ buttonText }}
+          :href="eventUrl"
+          color="primary"
+          elevation="0"
+          small
+          outlined>
+          <span class="text-none">
+            {{ buttonText }}
+          </span>
         </v-btn>
       </div>
     </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/DatePollPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/DatePollPlugin.vue
@@ -29,10 +29,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div class="mt-1">
         <v-btn
-          class="btn primary px-2"
-          outlined
-          small>
-          {{ $t('Notification.agenda.event.reply') }}
+          :href="eventUrl"
+          color="primary"
+          elevation="0"
+          small
+          outlined>
+          <span class="text-none">
+            {{ $t('Notification.agenda.event.reply') }}
+          </span>
         </v-btn>
       </div>
     </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReminderPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReminderPlugin.vue
@@ -32,10 +32,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div class="mt-1">
         <v-btn
-          class="btn primary px-2"
-          outlined
-          small>
-          {{ $t('Notification.agenda.event.view') }}
+          :href="eventUrl"
+          color="primary"
+          elevation="0"
+          small
+          outlined>
+          <span class="text-none">
+            {{ $t('Notification.agenda.event.view') }}
+          </span>
         </v-btn>
       </div>
     </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReplyPlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/EventReplyPlugin.vue
@@ -29,10 +29,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div class="mt-1">
         <v-btn
-          class="btn primary px-2"
-          outlined
-          small>
-          {{ $t('Notification.agenda.event.view') }}
+          :href="eventUrl"
+          color="primary"
+          elevation="0"
+          small
+          outlined>
+          <span class="text-none">
+            {{ $t('Notification.agenda.event.view') }}
+          </span>
         </v-btn>
       </div>
     </template>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/PollVotePlugin.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-notifications/components/PollVotePlugin.vue
@@ -29,10 +29,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </div>
       <div class="mt-1">
         <v-btn
-          class="btn primary px-2"
-          outlined
-          small>
-          {{ $t('Notification.agenda.event.viewPoll') }}
+          :href="eventUrl"
+          color="primary"
+          elevation="0"
+          small
+          outlined>
+          <span class="text-none">
+            {{ $t('Notification.agenda.event.viewPoll') }}
+          </span>
         </v-btn>
       </div>
     </template>


### PR DESCRIPTION
Before this fix, the agenda notification button are white, and should be transparent This commit update the button so that it is the same as in meeds