### PR TITLE
fix: Move agenda connectors extension in a group js - EXO-67332 (#589)

### DIFF
--- a/agenda-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -174,6 +174,9 @@
       <module>commons-cometd3</module>
       <as>cCometd</as>
     </depends>
+    <depends>
+      <module>AgendaConnectorsExtensions</module>
+    </depends>
   </module>
 
   <module>
@@ -255,5 +258,6 @@
       <module>extensionRegistry</module>
     </depends>
   </module>
+
 
 </gatein-resources>


### PR DESCRIPTION
Before this fix, agenda connectors are loaded with a dynamic container, present in all pages. As this container is not in the new administration site, the connectors are not loaded This commit creates a load-group for all aganda connectors. Addons defining new agenda connectors will have to put their js in this group