### PR TITLE
fix: Move agenda connectors extension in a group js - EXO-67332

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-admin-settings/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-admin-settings/main.js
@@ -31,5 +31,5 @@ export function init() {
       vuetify,
       i18n
     }, `#${appId}`, 'Agenda administration');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('ConnectorsExtensions'));
 }

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorsDrawer.vue
@@ -89,6 +89,7 @@
         </div>
       </template>
     </exo-drawer>
+    <div id="agendaConnectorSettingsDrawer" />
     <exo-confirm-dialog
       ref="confirmConnectDialog"
       :title="confirmConnectDialogLabels.title"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-user-setting/main.js
@@ -37,5 +37,5 @@ export function init() {
       vuetify,
       i18n
     }, appElement, 'User Settings Agenda');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('ConnectorsExtensions'));
 }

--- a/agenda-webapps/src/main/webapp/vue-app/agenda/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/main.js
@@ -32,5 +32,5 @@ export function init() {
       vuetify,
       i18n
     }, `#${appId}`, 'Agenda');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('ConnectorsExtensions'));
 }


### PR DESCRIPTION
Before this fix, it was impossible to configure exchange connector in user settings.

In this commit, we load AgendaConnector extension when the vue component is loaded