### PR TITLE
fix: UI Cleanup portlet Agenda timeline - EXO-67617

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
@@ -8,18 +8,18 @@
         min-height="auto"
         min-width="100%"
         dense>
-        <v-list-item class="agenda-timeline-month-title" dense>
-          <v-list-item-action class="event-timeline-day" />
-          <v-list-item-action-text class="subtitle-1 me-2 text-capitalize">
+        <v-list-item class="agenda-timeline-month-title px-0" dense>
+          <v-list-item-action-text class="subtitle-1 text-capitalize text-color">
             <date-format :value="month" :format="monthFormat" />
           </v-list-item-action-text>
-          <v-list-item-content>
+          <v-list-item-content class="ms-2">
             <v-divider />
           </v-list-item-content>
         </v-list-item>
         <v-list-item
           v-for="eventDay in eventsDaysByMonth[month]"
           :key="eventDay"
+          class="px-0"
           dense>
           <v-list-item-action
             :class="toDay === eventDay && 'primary--text'"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-flex class="agenda-timeline-header d-flex mx-3 my-2">
+  <v-flex class="agenda-timeline-header d-flex mb-5">
     <div class="d-flex align-center">
-      <a :href="agendaBaseLink" class="body-1 text-uppercase text-sub-title">
+      <a :href="agendaBaseLink" class="widget-text-header text-capitalize-first-letter">
         {{ $t('agenda') }}
       </a>
       <agenda-pending-invitation-badge
@@ -17,6 +17,7 @@
       <v-btn
         :disabled="!canCreateEvent"
         :title="$t('agenda.button.addEvent')"
+        class="primary--text"
         icon
         text
         @click="openEventForm">

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-app class="agenda-application border-box-sizing" flat>
-    <v-main class="white">
+  <v-app class="agenda-application" flat>
+    <v-card class="white pa-5 card-border-radius" flat>
       <agenda-timeline-header
         :current-space="currentSpace"
         :current-calendar="currentCalendar"
@@ -11,7 +11,7 @@
         :agenda-base-link="agendaBaseLink"
         :loading="loading || !initialized"
         :limit="limit" />
-    </v-main>
+    </v-card>
     <agenda-event-dialog
       ref="eventFormDialog"
       :current-space="currentSpace"


### PR DESCRIPTION
before this change, the Agenda timeLine portlet does not match the new UI specifications rules( Title + radius + padding )
after this change, the portlet matches to the new UI specifications