### PR TITLE
fix: fix the 3 first letter of the day should be in the same line - EXO-67617

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -680,9 +680,9 @@
     }
   }
   .event-timeline-day {
-    min-width: 32px;
-    width: 32px;
-    max-width: 32px;
+    min-width: 36px;
+    width: 36px;
+    max-width: 36px;
     margin-top: 7px!important;
     margin-right: 8px!important;
     white-space: pre-line;


### PR DESCRIPTION
before this fix, some day items in agenda time line are displayed in two lines
after this change, the day letters are displayed int same line by increasing the with of the the element
