### PR TITLE
fix: Fix event duplicated when recurring event is updated - EXO-67588

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -125,12 +125,16 @@ export default {
 
                 }
                 delete recurrentEvent.id;
-                return this.$eventService.createEvent(recurrentEvent);
-              })
-              .then(() => {
-                this.close();
-                this.$root.$emit('agenda-event-saved', recurrentEvent);
-              });
+                setTimeout(() => {
+                  return this.$eventService.createEvent(recurrentEvent).then((event)=> {
+                    recurrentEvent = event;
+                  })
+                    .then(() => {
+                      this.close();
+                      this.$root.$emit('agenda-event-saved', recurrentEvent);
+                    });
+                }, 200);
+              });           
           }
         });
     },


### PR DESCRIPTION
Prior to this change, when we connect to the Google personal calendar, we change the title of the recurring event and we select "this and upcoming events" then the recurring event is duplicated. After this commit, we insist on sending the newly created recurring event to avoid duplicating its creation when pushing it to the Google connector.