### PR TITLE
fix: Prevent the sending of event reminders for the deleted calendar - EXO-68784

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
@@ -28,12 +28,14 @@ import org.exoplatform.agenda.constant.EventStatus;
 import org.exoplatform.agenda.exception.AgendaException;
 import org.exoplatform.agenda.exception.AgendaExceptionType;
 import org.exoplatform.agenda.model.*;
+import org.exoplatform.agenda.model.Calendar;
 import org.exoplatform.agenda.storage.*;
 import org.exoplatform.agenda.util.Utils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.command.NotificationCommand;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.listener.ListenerService;
@@ -224,8 +226,10 @@ public class AgendaEventReminderServiceImpl implements AgendaEventReminderServic
     List<EventReminder> reminders = reminderStorage.getEventReminders(currentMinute, endCurrentMinute);
     for (EventReminder eventReminder : reminders) {
       Event event = eventStorage.getEventById(eventReminder.getEventId());
+      Calendar calendar = ExoContainerContext.getService(AgendaCalendarService.class).getCalendarById(event.getCalendarId());
       // do not send a reminder notification of the Recurrent parent event.
-      if (event.getRecurrence() == null) {
+      // do not send a reminder notification if the calendar is removed!
+      if (event.getRecurrence() == null && calendar != null && !calendar.isDeleted()) {
         sendReminderNotification(eventReminder);
       }
     }

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
@@ -22,6 +22,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import org.exoplatform.agenda.model.Calendar;
 import org.exoplatform.commons.api.notification.service.WebNotificationService;
 import org.junit.Test;
 
@@ -453,6 +454,12 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
     agendaEventReminderService.sendReminders();
     // Assert receiving the reminder notification for the non-recurring event.
     assertEquals(notificationSize + 1, webNotificationService.getNumberOnBadge(testuser1Identity.getRemoteId()));
+    webNotificationService.resetNumberOnBadge(testuser1Identity.getRemoteId());
+    //
+    calendar.setDeleted(true);
+    agendaEventReminderService.sendReminders();
+    // assert no more notifications
+    assertEquals(2 , webNotificationService.getNumberOnBadge(testuser1Identity.getRemoteId()));
   }
 
 }


### PR DESCRIPTION
Prior to this change , users still received the event reminder notification for deleted space events , this change is going to prevent the sending of the event reminder for the deleted calendar.