### PR TITLE
fix: fix retreiving pending event for deleted events - EXO-68786

### DIFF
--- a/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaEventService.java
+++ b/agenda-api/src/main/java/org/exoplatform/agenda/service/AgendaEventService.java
@@ -352,7 +352,7 @@ public interface AgendaEventService {
                                long userIdentityId,
                                ZoneId userTimeZone,
                                int offset,
-                               int limit) throws IllegalAccessException;
+                               int limit) throws Exception;
 
   /**
    * Count pending events that the selected user didn't answered yet
@@ -363,6 +363,6 @@ public interface AgendaEventService {
    * @throws IllegalAccessException when user is not an allowed to access one of
    *           ownerIds events
    */
-  long countPendingEvents(List<Long> ownerIds, long userIdentityId) throws IllegalAccessException;
+  long countPendingEvents(List<Long> ownerIds, long userIdentityId) throws Exception;
 
 }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/dao/EventDAO.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/dao/EventDAO.java
@@ -215,8 +215,17 @@ public class EventDAO extends GenericDAOJPAImpl<EventEntity, Long> {
                               : resultList.stream().map(tuple -> tuple.get(0, Long.class)).collect(Collectors.toList());
   }
 
+  public List<Long> getUserEventCalenderIds(Long userIdentityId) {
+    TypedQuery<Tuple> query = getEntityManager().createNamedQuery("AgendaEvent.getUserEventCalenderIds", Tuple.class);
+    query.setParameter("userIdentityId", userIdentityId);
+    List<Tuple> resultList = query.getResultList();
+    return resultList == null ? Collections.emptyList()
+                              : resultList.stream().map(tuple -> tuple.get(0, Long.class)).collect(Collectors.toList());
+  }
+
   public List<Long> getPendingEventIds(Long userIdentityId,
                                        List<Long> attendeeIds,
+                                       List<Long> calenderIds,
                                        Date fromDate,
                                        int offset,
                                        int limit) {
@@ -225,6 +234,7 @@ public class EventDAO extends GenericDAOJPAImpl<EventEntity, Long> {
     query.setParameter("response", EventAttendeeResponse.NEEDS_ACTION);
     query.setParameter("userIdentityId", userIdentityId);
     query.setParameter("attendeeIds", attendeeIds);
+    query.setParameter("calenderIds", calenderIds);
     query.setParameter("date", fromDate);
     if (offset >= 0) {
       query.setFirstResult(offset);
@@ -243,12 +253,14 @@ public class EventDAO extends GenericDAOJPAImpl<EventEntity, Long> {
 
   public Long countPendingEvents(Long userIdentityId,
                                  List<Long> attendeeIds,
+                                 List<Long> calenderIds,
                                  Date fromDate) {
     TypedQuery<Long> query = getEntityManager().createNamedQuery("AgendaEvent.countPendingEvents", Long.class);
     query.setParameter("status", EventStatus.CONFIRMED);
     query.setParameter("response", EventAttendeeResponse.NEEDS_ACTION);
     query.setParameter("userIdentityId", userIdentityId);
     query.setParameter("attendeeIds", attendeeIds);
+    query.setParameter("calenderIds", calenderIds);
     query.setParameter("date", fromDate);
     try {
       Long count = query.getSingleResult();

--- a/agenda-services/src/main/java/org/exoplatform/agenda/entity/EventEntity.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/entity/EventEntity.java
@@ -83,6 +83,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
           name = "AgendaEvent.getPendingEventIds",
           query = "SELECT DISTINCT(ev.id), ev.updatedDate FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
+              + " INNER JOIN ev.calendar cal"
               + " WHERE ev.status = :status"
               + " AND (ev.endDate IS NULL OR ev.endDate > :date)"
               + " AND ("
@@ -91,6 +92,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
               + " )"
               + " AND att.identityId IN (:attendeeIds)"
               + " AND att.response = :response"
+              + " AND cal.id IN (:calenderIds)"
               + " AND NOT EXISTS("
               + "   SELECT att2.id FROM AgendaEventAttendee att2"
               + "   WHERE att2.event.id = ev.id"
@@ -103,6 +105,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
           name = "AgendaEvent.countPendingEvents",
           query = "SELECT count(DISTINCT ev.id) FROM AgendaEvent ev"
               + " INNER JOIN ev.attendees att"
+              + " INNER JOIN ev.calendar cal"
               + " WHERE ev.status = :status"
               + " AND (ev.endDate IS NULL OR ev.endDate > :date)"
               + " AND ("
@@ -111,6 +114,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
               + " )"
               + " AND att.identityId IN (:attendeeIds)"
               + " AND att.response = :response"
+              + " AND cal.id IN (:calenderIds)"
               + " AND NOT EXISTS("
               + "   SELECT att2.id FROM AgendaEventAttendee att2"
               + "   WHERE att2.event.id = ev.id"
@@ -220,6 +224,13 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
               + " AND (ev.endDate IS NULL OR ev.endDate > :date)"
               + " AND att.identityId IN (:attendeeIds)"
               + " AND cal.ownerId IN (:ownerIds)"
+      ),
+      @NamedQuery(
+          name = "AgendaEvent.getUserEventCalenderIds",
+          query = "SELECT DISTINCT cal.id FROM AgendaEvent ev"
+              + " INNER JOIN ev.attendees att"
+              + " INNER JOIN ev.calendar cal"
+              + " WHERE att.identityId = :userIdentityId "
       ),
   }
 )

--- a/agenda-services/src/main/java/org/exoplatform/agenda/storage/AgendaEventStorage.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/storage/AgendaEventStorage.java
@@ -69,11 +69,12 @@ public class AgendaEventStorage {
   public List<Long> getPendingEventIds(Long userIdentityId,
                                        List<Long> ownerIds,
                                        List<Long> attendeeIds,
+                                       List<Long> calenderIds,
                                        int offset,
                                        int limit) {
     Date now = getNowDate();
     if (ownerIds == null || ownerIds.isEmpty()) {
-      return this.eventDAO.getPendingEventIds(userIdentityId, attendeeIds, now, offset, limit);
+      return this.eventDAO.getPendingEventIds(userIdentityId, attendeeIds, calenderIds, now, offset, limit);
     } else {
       return this.eventDAO.getPendingEventIdsByOwnerIds(userIdentityId, ownerIds, attendeeIds, now, offset, limit);
     }
@@ -81,13 +82,18 @@ public class AgendaEventStorage {
 
   public long countPendingEvents(Long userIdentityId,
                                  List<Long> ownerIds,
-                                 List<Long> attendeeIds) {
+                                 List<Long> attendeeIds,
+                                 List<Long> calenderIds) {
     Date now = getNowDate();
     if (ownerIds == null || ownerIds.isEmpty()) {
-      return this.eventDAO.countPendingEvents(userIdentityId, attendeeIds, now);
+      return this.eventDAO.countPendingEvents(userIdentityId, attendeeIds, calenderIds, now);
     } else {
       return this.eventDAO.countPendingEventsByOwnerIds(userIdentityId, ownerIds, attendeeIds, now);
     }
+  }
+
+  public List<Long> getUserEventCalenderIds(Long userIdentityId) {
+    return this.eventDAO.getUserEventCalenderIds(userIdentityId);
   }
 
   public List<Long> getEventDatePollIds(Long userIdentityId,


### PR DESCRIPTION
Before this change, when creating an eventX in space and inviting a user, the user is added as an attendee. After deleting the space and when retrieving user pending events, the eventX belongs to the pending events even if its calendar is deleted since the SQL request retrieves the event of the user that needs a response and does not check the calendar After this change, we retrieve the pending events depending on the filtered calendars of the attended user event