### PR TITLE
fix: Created events not visible - EXO-68824

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventSave.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventSave.vue
@@ -51,6 +51,7 @@ export default {
     saved(event) {
       this.$refs.recurrentEventConfirm.close();
       this.$root.$emit('agenda-event-saved', event);
+      this.$root.$emit('agenda-refresh');
     },
   },
 };

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -287,7 +287,10 @@ export default {
           this.$root.$emit('agenda-event-saved', event);
           this.close();
         })
-        .finally(() => this.saving = false);
+        .finally(() => {
+          this.saving = false;
+          this.$root.$emit('agenda-refresh');
+        });
     },
   }
 };


### PR DESCRIPTION
Before this change, when create a space, go in agenda application and create a new event, When going back to agenda view, the event is not visible. To resolve this problem, when saving a new event refresh the event list. After this change, the event is visible directly.

(cherry picked from commit f1ea089cf2ae51da34d41922db83d126bda3793e)