### PR TITLE
fix: Events in agenda timeline are not synchronized with agenda connectors - EXO-69488

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
@@ -32,5 +32,5 @@ export function init() {
       vuetify,
       i18n
     }, `#${appId}`, 'Agenda Timeline');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('ConnectorsExtensions'));
 }


### PR DESCRIPTION
Before this, the agenda connectors extensions were not loaded in Agenda TimeLine application This fix add instructions to load AgendaConnectorsExtensions in agendaTimeline