### PR TITLE
fix: fix sending email with user local when using user email - EXO-69927

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
@@ -166,16 +166,23 @@ export default {
       const words = input!== null ? input.split(' ') : '';
       const email = words[words.length - 1];
       if (reg.test(email)) {
-        this.event.attendees.push({identity: {
-          id: `${email}`,
-          remoteId: email,
-          identityId: email,
-          providerId: 'GUEST_USER',
-          profile: {
-            fullName: email,
-            avatarUrl: '/portal/rest/v1/social/users/default-image/avatar',
-          },
-        }});
+        this.$userService.getUserByEmail(email)
+          .then(user => {
+            if (user.remoteId){
+              this.event.attendees.push({identity: user});
+            } else {
+              this.event.attendees.push({identity: {
+                id: `${email}`,
+                remoteId: email,
+                identityId: email,
+                providerId: 'GUEST_USER',
+                profile: {
+                  fullName: email,
+                  avatarUrl: '/portal/rest/v1/social/users/default-image/avatar',
+                },
+              }});
+            }
+          });
       }
       this.$refs.invitedAttendeeAutoComplete.clear();
     },


### PR DESCRIPTION
before this change, when using the user email as userId in an email notification, the email is sent in EN even user's language setting is FR since it could not find a user by name with an email
After this change, when userId contains an @ we search for the user with its email and add his user name to event attendees so the notification is sent with user settings