### PR TITLE
fix: Add webconferencing in event - EXO-68458

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormConference.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormConference.vue
@@ -99,17 +99,17 @@ export default {
   watch: {
     conferenceURL(newVal) {
       if (!newVal) {
-        this.event.conferences = [];
+        this.$set(this.event, 'conferences', null);
       } else {
-        this.event.conferences = [{
+        this.$set(this.event, 'conferences', [{
           url: newVal,
           type: 'manual',
-        }];
+        }]);
       }
     },
     conferenceProvider() {
       this.conferenceURL=null;
-      this.$set(this.event, 'conferences', []);
+      this.$set(this.event, 'conferences', null);
     },
   },
   mounted() {
@@ -117,7 +117,7 @@ export default {
       this.conferenceURL = this.event.conferences[0].url;
     } else {
       this.conferenceURL = null;
-      this.event.conferences = [];
+      this.$set(this.event, 'conferences', null);
     }
   },
   methods: {


### PR DESCRIPTION
Before this fix, the create conference button was not working well. The state of variable event was not correctly updated, and then not detected by vue framework This commit ensure that the conference property is correctly set in the event object, so that, the change is detected correctly in each case