### PR TITLE
fix: When editing an event, visio conference button is "create a visio" - EXO-72138

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormConference.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormConference.vue
@@ -106,11 +106,7 @@ export default {
           type: 'manual',
         }]);
       }
-    },
-    conferenceProvider() {
-      this.conferenceURL=null;
-      this.$set(this.event, 'conferences', null);
-    },
+    }
   },
   mounted() {
     if (this.isConferenceEnabled && this.event && this.event.conferences && this.event.conferences.length) {


### PR DESCRIPTION
Before this fix, when editing an event, the parameter event.conferenceUrl was reset to null when providers are loaded, which is not necessary, and leads to display the "create visio" button instead of the visio link.