### PR TITLE
fix: When opening agenda quick form drawer the first time the agenda owner is not set - EXO-72629

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormCalendarOwner.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormCalendarOwner.vue
@@ -78,6 +78,7 @@ export default {
     this.$root.$on('current-user',user => {
       this.currentUser = user;
     });
+    this.reset();
   },
   methods: {
     resetCustomValidity() {


### PR DESCRIPTION
Before this fix, in a space, in agenda app, the agenda owner is not filled in the quick form event drawer This is because the declaration of the event agenda-event-form-opened comes after the event is launched

This commit ensure to correctly read the event owner when the drawer is opened.