### PR TITLE
fix: Agenda timeline gadget do not correctly display webconferencing providers - EXO-72163 

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -198,6 +198,8 @@ export default {
     }
   },
   created() {
+
+    console.log('providers',this.conferenceProvider);
     this.$root.$on('agenda-event-quick-form', event => {
       this.event = null;
       this.$nextTick().then(() => {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -70,12 +70,12 @@ export default {
   computed: {
     enabledConferenceProviderName() {
       return this.settings
-              && this.settings.webConferenceProviders
-              && this.settings.webConferenceProviders.length
-              && this.settings.webConferenceProviders[0];
+              && this.conferenceProviders
+              && this.conferenceProviders.length > 0
+              && this.conferenceProviders.find((provider) => provider.configured);
     },
     conferenceProvider() {
-      return this.conferenceProviders && this.enabledConferenceProviderName && this.conferenceProviders.find(provider => provider.isInitialized && provider.linkSupported && provider.groupSupported && this.enabledConferenceProviderName === provider.getType());
+      return this.conferenceProviders && this.enabledConferenceProviderName && this.conferenceProviders.find(provider => provider.isInitialized && provider.linkSupported && provider.groupSupported && this.enabledConferenceProviderName.getType() === provider.getType());
     },
     weekdays() {
       return this.settings && this.$agendaUtils.getWeekSequenceFromDay(this.settings.agendaWeekStartOn);
@@ -149,16 +149,23 @@ export default {
             if (settings) {
               this.settings = settings;
               this.calendarType = this.settings && this.settings.agendaDefaultView;
+              this.refreshProviders(eXo.env.portal.spaceName);
+
             }
-            return this.$webConferencingService.getAllProviders();
-          })
-          .then(providers => {
-            this.conferenceProviders = providers;
-            return this.$nextTick();
           })
           .finally(() => {
             this.settingsLoaded = true;
           });
+      }
+    },
+    refreshProviders(spacePrettyName) {
+      if (spacePrettyName) {
+        this.$webConferencingService.getAllProviders(spacePrettyName).then((providers) => {
+          this.conferenceProviders = providers;
+          return this.$nextTick();
+        });
+      } else {
+        this.conferenceProviders = null;
       }
     },
     retrieveEvents() {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
@@ -32,5 +32,8 @@ export function init() {
       vuetify,
       i18n
     }, `#${appId}`, 'Agenda Timeline');
-  }).finally(() => Vue.prototype.$utils.includeExtensions('ConnectorsExtensions'));
+  }).finally(() => {
+    Vue.prototype.$utils.includeExtensions('VisioConnector');
+    Vue.prototype.$utils.includeExtensions('ConnectorsExtensions');
+  });
 }


### PR DESCRIPTION
Before this fix, visio connectors extensions were not loaded by AgendaTimeline gadget. In addition, webconf providers initialization were not updated when modified in agenda component

This commit adds the visio extension and apply needed modification in agendatimeline gadget