### PR TITLE
feat: Delete usage of Jcabi to use AspectJ Maven Plugin - MEED-7544 - Meeds-io/meeds#2417

### DIFF
--- a/agenda-services/pom.xml
+++ b/agenda-services/pom.xml
@@ -78,10 +78,6 @@
     <finalName>agenda-services</finalName>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
         <configuration>
@@ -101,18 +97,6 @@
             </info>
           </swaggerConfig>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This change will delete the usage of Jcabi Maven plugin which is incompatible with newer AspectJ versions and use AspectJ Maven plugin instead