### PR TITLE
fix: Agenda detail : webconf no displayed when accessing from agenda timeline - EXO-74164

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -124,6 +124,8 @@ export default {
     this.$root.$on('agenda-refresh', this.retrieveEvents);
     this.$root.$on('agenda-event-saved', this.retrieveEvents);
     this.$root.$on('agenda-event-deleted', this.retrieveEvents);
+    this.$root.$on('agenda-event-change-owner', this.refreshProviders);
+
 
     this.spaceId = eXo.env.portal.spaceId;
 


### PR DESCRIPTION
Before this fix, when a user click on an event in agenda timeline, the conference link is not displayed if the event have one This is because when opening the event from the timeline, the webconf providers are not refreshed from the space of the event like it is the case in the agenda standalone application This commit ensure agendaTimeline to react on event agenda-event-change-owner, and then reload providers for the space of the selected event