### PR TITLE
fix: Hide Download ICS CTA button when an Agenda connector is connected - EXO-73528

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
@@ -139,7 +139,7 @@
             class="mt-4 mr-auto width-full"
             @download-ics="downloadICS"/>
           <agenda-ics
-            v-if="addToMyAgenda"
+            v-if="addToMyAgenda && !connectedConnector"
             :settings="settings"
             :event="event"
             :connectors="enabledconnectors"


### PR DESCRIPTION
When a remote agenda connector is connected, the CTAQ button **Add top my Agenda** should be hidden