### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202 

### DIFF
--- a/agenda-services/src/main/resources/db/changelog/agenda-rdbms.db.changelog.xml
+++ b/agenda-services/src/main/resources/db/changelog/agenda-rdbms.db.changelog.xml
@@ -25,6 +25,8 @@
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-1">
+    <validCheckSum>9:b15bee7b054fbf642b28d722b3029b4d</validCheckSum>
+    <validCheckSum>9:95ed708605e433081276ea894a20ecf2</validCheckSum>
     <createTable tableName="EXO_AGENDA_CALENDAR">
       <column name="CALENDAR_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_CALENDAR" />
@@ -33,31 +35,35 @@
         <constraints nullable="false" />
       </column>
       <column name="IS_SYSTEM" type="BOOLEAN" defaultValueBoolean="false" />
-      <column name="DESCRIPTION" type="NVARCHAR(2000)" />
-      <column name="COLOR" type="NVARCHAR(20)" />
+      <column name="DESCRIPTION" type="VARCHAR(2000)" />
+      <column name="COLOR" type="VARCHAR(20)" />
       <column name="CREATED_DATE" type="TIMESTAMP" defaultValueComputed="NULL" />
       <column name="UPDATED_DATE" type="TIMESTAMP" defaultValueComputed="NULL" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-2">
+    <validCheckSum>9:070dbf24bf50b6695cd77c8ab5176d10</validCheckSum>
+    <validCheckSum>9:9e8cf87c8007c44375872eed6ee87ae8</validCheckSum>
     <createTable tableName="EXO_AGENDA_REMOTE_PROVIDER">
       <column name="AGENDA_PROVIDER_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_PROVIDER" />
       </column>
-      <column name="NAME" type="NVARCHAR(200)">
+      <column name="NAME" type="VARCHAR(200)">
         <constraints nullable="false" />
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-3">
+    <validCheckSum>9:65a1f4bc0c72aa10c3f6a40ea66b05f4</validCheckSum>
+    <validCheckSum>9:bb230b3cbf0b6676fb9daccf62b2b2e6</validCheckSum>
     <createTable tableName="EXO_AGENDA_EVENT">
       <column name="EVENT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_EVENT" />
@@ -80,10 +86,10 @@
       <column name="START_DATE" type="TIMESTAMP" defaultValueComputed="NULL" />
       <column name="END_DATE" type="TIMESTAMP" defaultValueComputed="NULL" />
       <column name="OCCURRENCE_ID" type="TIMESTAMP" />
-      <column name="SUMMARY" type="NVARCHAR(2000)" />
+      <column name="SUMMARY" type="VARCHAR(2000)" />
       <column name="DESCRIPTION" type="TEXT" />
-      <column name="COLOR" type="NVARCHAR(20)" />
-      <column name="LOCATION" type="NVARCHAR(2000)" />
+      <column name="COLOR" type="VARCHAR(20)" />
+      <column name="LOCATION" type="VARCHAR(2000)" />
       <column name="AVAILABILITY" type="SMALLINT" />
       <column name="STATUS" type="SMALLINT" />
       <column name="ALL_DAY" type="BOOLEAN" />
@@ -91,11 +97,12 @@
       <column name="ALLOW_ATTENDEE_TO_INVITE" type="BOOLEAN" defaultValueBoolean="false" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-4">
+    <validCheckSum>9:14a1e731d976df83d364a94f0ef5b031</validCheckSum>
     <createTable tableName="EXO_AGENDA_RECURRENCE">
       <column name="EVENT_RECURRENCE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_EVENT_RECURRENCE" />
@@ -111,11 +118,12 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-5">
+    <validCheckSum>9:f6417ec55733154121b59ac2c2421ce1</validCheckSum>
     <createTable tableName="EXO_AGENDA_CONFERENCE">
       <column name="EVENT_CONFERENCE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_CONFERENCE" />
@@ -130,11 +138,12 @@
       <column name="DESCRIPTION" type="TEXT" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-6">
+    <validCheckSum>9:31580c5ea4069126f608eae1ffb737c6</validCheckSum>
     <createTable tableName="EXO_AGENDA_ATTENDEE">
       <column name="EVENT_ATTENDEE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_ATTENDEE" />
@@ -150,11 +159,12 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-7">
+    <validCheckSum>9:44b847790369418e7c0cf746464ced8b</validCheckSum>
     <createTable tableName="EXO_AGENDA_ATTACHMENT">
       <column name="EVENT_ATTACHMENT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_ATTACHMENT" />
@@ -167,11 +177,12 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-8">
+    <validCheckSum>9:065e51267af28fe824d62b1277aa81b9</validCheckSum>
     <createTable tableName="EXO_AGENDA_REMINDER">
       <column name="EVENT_REMINDER_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_REMINDER" />
@@ -189,7 +200,7 @@
       <column name="TRIGGER_DATE" type="TIMESTAMP" defaultValueComputed="NULL" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
@@ -249,8 +260,9 @@
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-16">
+    <validCheckSum>9:7b49b943c80d4d54aca05e17a0e6fc6a</validCheckSum>
     <addColumn tableName="EXO_AGENDA_REMOTE_PROVIDER">
-      <column name="CLIENT_API" type="NVARCHAR(2000)" />
+      <column name="CLIENT_API" type="VARCHAR(2000)" />
     </addColumn>
   </changeSet>
 
@@ -366,6 +378,8 @@
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-28">
+    <validCheckSum>9:40e26ee1656d821f32bdaf065b093a7e</validCheckSum>
+    <validCheckSum>9:a13595b1e99e8e9f99a9d051ee479b77</validCheckSum>
     <createTable tableName="EXO_AGENDA_GUESTS">
       <column name="EVENT_GUEST_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AGENDA_GUEST"/>
@@ -373,12 +387,12 @@
       <column name="EVENT_ID" type="BIGINT">
         <constraints nullable="false" foreignKeyName="FK_AGENDA_EVENT_GUEST" references="EXO_AGENDA_EVENT(EVENT_ID)"/>
       </column>
-      <column name="GUEST_EMAIL" type="NVARCHAR(200)">
+      <column name="GUEST_EMAIL" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   <changeSet author="agenda" id="1.0.0-29" dbms="oracle,postgresql,hsqldb">
@@ -393,14 +407,28 @@
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-32">
+    <validCheckSum>9:aa4e6a42a00fdeb2b8dca9b771419fc4</validCheckSum>
     <addColumn tableName="EXO_AGENDA_REMOTE_PROVIDER">
-      <column name="SECRET_KEY" type="NVARCHAR(2000)" />
+      <column name="SECRET_KEY" type="VARCHAR(2000)" />
     </addColumn>
   </changeSet>
 
   <changeSet author="agenda" id="1.0.0-33">
+    <validCheckSum>9:486ea8fd17138980551cb9e228fabdd5</validCheckSum>
     <addColumn tableName="EXO_AGENDA_REMOTE_PROVIDER">
-      <column name="SERVER_URL" type="NVARCHAR(1000)" />
+      <column name="SERVER_URL" type="VARCHAR(1000)" />
     </addColumn>
+  </changeSet>
+
+  <changeSet author="agenda" id="1.0.0-34">
+    <sql dbms="mysql">
+      ALTER TABLE EXO_AGENDA_CALENDAR CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE EXO_AGENDA_REMOTE_PROVIDER CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE EXO_AGENDA_EVENT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE EXO_AGENDA_RECURRENCE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE EXO_AGENDA_CONFERENCE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE EXO_AGENDA_ATTENDEE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE EXO_AGENDA_REMINDER CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4.
This commit adapt liquibase changes in order to apply this change.