### PR TITLE
fix: do not send creation/update web notif to creator/modifier - EXO-75329

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
@@ -52,15 +52,19 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
 
   private boolean                    isPushNotification;
 
+  private boolean                    isWebNotification;
+
   private PluginKey                  key;
 
   public AgendaTemplateBuilder(TemplateProvider templateProvider,
                                ExoContainer container,
                                PluginKey key,
-                               boolean pushNotification) {
+                               boolean pushNotification,
+                               boolean webNotification) {
     this.templateProvider = templateProvider;
     this.container = container;
     this.isPushNotification = pushNotification;
+    this.isWebNotification = webNotification;
     this.key = key;
   }
 
@@ -101,10 +105,15 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
       if (StringUtils.isBlank(notificationURL)) {
         notificationURL = getEventURL(event);
       }
-      String pushNotificationURL = isPushNotification ? notificationURL : null;
 
       String username = notification.getTo();
       long identityId = Utils.getIdentityIdByUsername(getIdentityManager(), username);
+
+      String modifierIdentityId = notification.getValueOwnerParameter(STORED_PARAMETER_MODIFIER_IDENTITY_ID);
+
+      if((isPushNotification || isWebNotification) && StringUtils.isNotBlank(modifierIdentityId) && modifierIdentityId.equals(String.valueOf(identityId))) {
+        return null;
+      }
       AgendaUserSettings agendaUserSettings = getAgendaUserSettingsService().getAgendaUserSettings(identityId);
       ZoneId timeZone;
       if (agendaUserSettings != null && agendaUserSettings.getTimeZoneId() != null) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
@@ -106,6 +106,7 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
         notificationURL = getEventURL(event);
       }
 
+      String pushNotificationURL = isPushNotification ? notificationURL : null;
       String username = notification.getTo();
       long identityId = Utils.getIdentityIdByUsername(getIdentityManager(), username);
 
@@ -131,7 +132,11 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
                                                                 notification,
                                                                 timeZone);
       MessageInfo messageInfo = new MessageInfo();
-      messageInfo.subject(notification.getValueOwnerParameter(STORED_PARAMETER_EVENT_TITLE));
+      if (pushNotificationURL != null) {
+        messageInfo.subject(pushNotificationURL);
+      } else {
+        messageInfo.subject(notification.getValueOwnerParameter(STORED_PARAMETER_EVENT_TITLE));
+      }
       messageInfo.body(TemplateUtils.processGroovy(templateContext));
 
       String ownerId = notification.getValueOwnerParameter(STORED_PARAMETER_EVENT_OWNER_ID);

--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/provider/MailTemplateProvider.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/provider/MailTemplateProvider.java
@@ -20,9 +20,9 @@ import static org.exoplatform.agenda.util.NotificationUtils.*;
 public class MailTemplateProvider extends TemplateProvider {
   public MailTemplateProvider(ExoContainer container, InitParams initParams) {
     super(initParams);
-    this.templateBuilders.put(EVENT_ADDED_KEY, new AgendaTemplateBuilder(this, container, EVENT_ADDED_KEY, false));
-    this.templateBuilders.put(EVENT_MODIFIED_KEY, new AgendaTemplateBuilder(this, container, EVENT_MODIFIED_KEY, false));
-    this.templateBuilders.put(EVENT_CANCELLED_KEY, new AgendaTemplateBuilder(this, container, EVENT_CANCELLED_KEY, false));
+    this.templateBuilders.put(EVENT_ADDED_KEY, new AgendaTemplateBuilder(this, container, EVENT_ADDED_KEY, false, false));
+    this.templateBuilders.put(EVENT_MODIFIED_KEY, new AgendaTemplateBuilder(this, container, EVENT_MODIFIED_KEY, false, false));
+    this.templateBuilders.put(EVENT_CANCELLED_KEY, new AgendaTemplateBuilder(this, container, EVENT_CANCELLED_KEY, false, false));
     this.templateBuilders.put(EVENT_REMINDER_KEY, new ReminderTemplateBuilder(this, container, EVENT_REMINDER_KEY, false));
     this.templateBuilders.put(EVENT_REPLY_KEY, new ReplyTemplateBuilder(this, container, EVENT_REPLY_KEY, false));
     this.templateBuilders.put(EVENT_DATE_POLL_KEY, new DatePollNotificationBuilder(this, container, EVENT_DATE_POLL_KEY, false));

--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/provider/WebTemplateProvider.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/provider/WebTemplateProvider.java
@@ -1,13 +1,13 @@
 package org.exoplatform.agenda.notification.provider;
 
+import static org.exoplatform.agenda.util.NotificationUtils.*;
+
 import org.exoplatform.agenda.notification.builder.*;
 import org.exoplatform.commons.api.notification.annotation.TemplateConfig;
 import org.exoplatform.commons.api.notification.annotation.TemplateConfigs;
 import org.exoplatform.commons.api.notification.channel.template.TemplateProvider;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.xml.InitParams;
-
-import static org.exoplatform.agenda.util.NotificationUtils.*;
 
 @TemplateConfigs(templates = {
     @TemplateConfig(pluginId = AGENDA_EVENT_ADDED_NOTIFICATION_PLUGIN, template = "war:/conf/agenda/templates/notification/push/EventPushPlugin.gtmpl"),
@@ -18,15 +18,15 @@ import static org.exoplatform.agenda.util.NotificationUtils.*;
     @TemplateConfig(pluginId = AGENDA_DATE_POLL_NOTIFICATION_PLUGIN, template = "war:/conf/agenda/templates/notification/push/DatePollPushPlugin.gtmpl"),
     @TemplateConfig(pluginId = AGENDA_VOTE_NOTIFICATION_PLUGIN, template = "war:/conf/agenda/templates/notification/push/VotePushPlugin.gtmpl")}
     )
-public class MobilePushTemplateProvider extends TemplateProvider {
-  public MobilePushTemplateProvider(ExoContainer container, InitParams initParams) {
+public class WebTemplateProvider extends TemplateProvider {
+  public WebTemplateProvider(ExoContainer container, InitParams initParams) {
     super(initParams);
-    this.templateBuilders.put(EVENT_ADDED_KEY, new AgendaTemplateBuilder(this, container, EVENT_ADDED_KEY, true, false));
-    this.templateBuilders.put(EVENT_MODIFIED_KEY, new AgendaTemplateBuilder(this, container, EVENT_MODIFIED_KEY, true, false));
-    this.templateBuilders.put(EVENT_CANCELLED_KEY, new AgendaTemplateBuilder(this, container, EVENT_CANCELLED_KEY, true, false));
-    this.templateBuilders.put(EVENT_REMINDER_KEY, new ReminderTemplateBuilder(this, container, EVENT_REMINDER_KEY, true));
-    this.templateBuilders.put(EVENT_REPLY_KEY, new ReplyTemplateBuilder(this, container, EVENT_REPLY_KEY, true));
-    this.templateBuilders.put(EVENT_DATE_POLL_KEY, new DatePollNotificationBuilder(this, container, EVENT_DATE_POLL_KEY, true));
-    this.templateBuilders.put(EVENT_DATE_VOTE_KEY, new VoteTemplateBuilder(this, container, EVENT_DATE_VOTE_KEY, true));
+    this.templateBuilders.put(EVENT_ADDED_KEY, new AgendaTemplateBuilder(this, container, EVENT_ADDED_KEY, false, true));
+    this.templateBuilders.put(EVENT_MODIFIED_KEY, new AgendaTemplateBuilder(this, container, EVENT_MODIFIED_KEY, false, true));
+    this.templateBuilders.put(EVENT_CANCELLED_KEY, new AgendaTemplateBuilder(this, container, EVENT_CANCELLED_KEY, false, true));
+    this.templateBuilders.put(EVENT_REMINDER_KEY, new ReminderTemplateBuilder(this, container, EVENT_REMINDER_KEY, false));
+    this.templateBuilders.put(EVENT_REPLY_KEY, new ReplyTemplateBuilder(this, container, EVENT_REPLY_KEY, false));
+    this.templateBuilders.put(EVENT_DATE_POLL_KEY, new DatePollNotificationBuilder(this, container, EVENT_DATE_POLL_KEY, false));
+    this.templateBuilders.put(EVENT_DATE_VOTE_KEY, new VoteTemplateBuilder(this, container, EVENT_DATE_VOTE_KEY, false));
   }
 }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/provider/WebTemplateProvider.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/provider/WebTemplateProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.exoplatform.agenda.notification.provider;
 
 import static org.exoplatform.agenda.util.NotificationUtils.*;

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
@@ -454,7 +454,7 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
     assertNotNull(eventReminder);
     agendaEventReminderService.sendReminders();
     // Assert receiving the reminder notification for the non-recurring event.
-    assertEquals(notificationSize + 2, webNotificationService.getNumberOnBadge(testuser1Identity.getRemoteId()));
+    assertEquals(notificationSize + 1, webNotificationService.getNumberOnBadge(testuser1Identity.getRemoteId()));
     webNotificationService.resetNumberOnBadge(testuser1Identity.getRemoteId());
     //
     calendar.setDeleted(true);

--- a/agenda-services/src/test/resources/conf/exo.agenda.service-configuration.xml
+++ b/agenda-services/src/test/resources/conf/exo.agenda.service-configuration.xml
@@ -323,6 +323,17 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>web.channel.agenda.template</name>
+      <set-method>registerTemplateProvider</set-method>
+      <type>org.exoplatform.agenda.notification.provider.WebTemplateProvider</type>
+      <init-params>
+        <value-param>
+          <name>channel-id</name>
+          <value>WEB_CHANNEL</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/notification-configuration.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/notification-configuration.xml
@@ -364,5 +364,16 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>web.channel.agenda.template</name>
+      <set-method>registerTemplateProvider</set-method>
+      <type>org.exoplatform.agenda.notification.provider.WebTemplateProvider</type>
+      <init-params>
+        <value-param>
+          <name>channel-id</name>
+          <value>WEB_CHANNEL</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>


### PR DESCRIPTION
This fix ignores sending Web/Push notifications for the event creator/modifier when an event is created/modified and still send it for other cases. It adds a constructor parameter to the Notification builder that let it know the type of the notification to decide when the notification is ignored.