### PR TITLE
fix: Fix event attachement issue for some email inbox providers

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/builder/AgendaTemplateBuilder.java
@@ -164,6 +164,7 @@ public class AgendaTemplateBuilder extends AbstractTemplateBuilder {
                                        timeZone);
       attachment.setInputStream(new ByteArrayInputStream(icsFileBytes));
       attachment.setMimeType("text/calendar;charset=utf-8;method=PUBLISH");
+      attachment.setName("event.ics");
       messageInfo.addAttachment(attachment);
 
 


### PR DESCRIPTION
Before this fix, the attachment was sent as raw text/Calendar without the attachment name. This PR will add an attachment name to avoid an attachment lack in some mail inboxes