### PR TITLE
fix: [BUG] - Add agenda & document page in the global site - EXO-75875

### DIFF
--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/agenda-portal-configuration.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/agenda-portal-configuration.xml
@@ -139,6 +139,59 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>AgendaApplicationPageUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updateNavigation">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/agenda/portal</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>agenda</string>
+                </value>
+                <value>
+                  <string>home/agenda</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/portal/portal/global/navigation.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/portal/portal/global/navigation.xml
@@ -33,5 +33,16 @@
             <visibility>SYSTEM</visibility>
             <page-reference>portal::global::agenda</page-reference>
         </node>
+        <node>
+        <name>home</name>
+        <label>#{portal.global.spaceHome}</label>
+        <visibility>SYSTEM</visibility>
+            <node>
+                <name>agenda</name>
+                <label>#{addon.agenda.navigation.node.label}</label>
+                <visibility>SYSTEM</visibility>
+                <page-reference>portal::global::agenda</page-reference>
+            </node>
+        </node>
     </page-nodes>
 </node-navigation>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -178,9 +178,7 @@ export default {
             this.currentSpace = space;
             if (space && space.identity && space.identity.id) {
               this.ownerIds = [space.identity.id];
-              const spaceGroupUri = this.currentSpace.groupId.replace(/\//g, ':');
-              this.agendaBaseLink = `${eXo.env.portal.context}/g/${spaceGroupUri}/${this.currentSpace.prettyName}/agenda`;
-
+              this.agendaBaseLink = `${eXo.env.portal.context}/s/${eXo.env.portal.spaceId}/agenda`;
               return this.$calendarService.getCalendars(0, 1, false, this.ownerIds);
             } else {
               this.agendaBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;


### PR DESCRIPTION
Prior to this fix, clicking on the header of the agenda timeline widget don't redirect to the space agenda application. this is due to the new apps navigation.

This commit adds the home/agenda node to the global site navigation so the user will be redirected to it in this case.