### PR TITLE
fix : in agenda gadget, day is not correctly truncated - EXO-76588

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -689,9 +689,9 @@
     }
   }
   .event-timeline-day {
-    min-width: 36px;
-    width: 36px;
-    max-width: 36px;
+    min-width: 38px;
+    width: 38px;
+    max-width: 38px;
     margin-top: 7px!important;
     margin-right: 8px!important;
     white-space: pre-line;


### PR DESCRIPTION
Before this fix, the truncated around the day in agenda gadget is KO. The dot is displayed in second line in fr, mon for monday is cut in english. This commit increase box size to correctly display the item

Resolves meeds-io/meeds#2777