### PR TITLE
fix: [BUG] - Event notification url domain issue - EXO-76606

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/NotificationUtils.java
@@ -659,13 +659,13 @@ public class NotificationUtils {
     String notificationURL = "";
     if (event != null) {
       if (occurrenceId == null) {
-        notificationURL = "/portal/" + currentSite + "/agendaa?eventId=" + event.getId();
+        notificationURL = "/portal/" + currentSite + "/agenda?eventId=" + event.getId();
       } else {
-        notificationURL = "/portal/" + currentSite + "/agendaa?parentId=" + event.getId() + "&occurrenceId="
+        notificationURL = "/portal/" + currentSite + "/agenda?parentId=" + event.getId() + "&occurrenceId="
                 + AgendaDateUtils.toRFC3339Date(occurrenceId, ZoneOffset.UTC);
       }
     } else {
-      notificationURL = "/portal/" + currentSite + "/agendaa";
+      notificationURL = "/portal/" + currentSite + "/agenda";
     }
     return notificationURL;
   }


### PR DESCRIPTION
Prior to this fix, onsite and push notifications related to events are created with the domain so if user open them in a different one he will be redirected.

This commit remove the domain from urls in the onsite notifications.