### PR TITLE
fix: Space filter isn't displaying spaces - EXO-76575

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/filter/AgendaFilterCalendarDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/filter/AgendaFilterCalendarDrawer.vue
@@ -56,7 +56,7 @@ export default {
     open() {
       this.$refs.calendarOwnersFilters.open();
       this.$nextTick().then(() => {
-        this.$refs.filterCalendarList.reset();
+        this.$refs.filterCalendarList?.reset();
       });
     },
   },

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/filter/AgendaFilterCalendarList.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/filter/AgendaFilterCalendarList.vue
@@ -110,6 +110,9 @@ export default {
       }
     },
   },
+  mounted() {
+    this.$root.$emit('agenda-calendar-owners-drawer-open');
+  },
   methods: {
     reset() {
       if (!this.calendars || !this.calendars.length) {


### PR DESCRIPTION
Before this change, when go to your own agenda App and click on filter button, spaces are not displayed. To resolve this problem, add the event call (agenda-calendar-owners-drawer-open) in the mounted method of the component (agenda-filter-calendar-list). After this change, my spaces are listed to choose from.

(cherry picked from commit 48de7ad04f01a377be0237753d90c824953b445b)