### PR TITLE
fix: Fix Agenda Dialog Parent Dom - Meeds-io/MIPs#175

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
@@ -3,8 +3,8 @@
     ref="eventDialog"
     v-model="dialog"
     :retain-focus="false"
-    :attach="parentDialogSelector"
     content-class="agendaEventDialog"
+    attach="#vuetify-apps"
     persistent
     fullscreen
     hide-overlay>
@@ -96,7 +96,6 @@ export default {
       dialog: false,
       saving: false,
       event: null,
-      parentDialogSelector: null,
       loadingMessage: false,
       originalEventString: null,
       isForm: false,
@@ -143,26 +142,6 @@ export default {
     },
   },
   created() {
-    if (this.isMobile) {
-      this.parentDialogSelector = '#vuetify-apps';
-    } else {
-      const parentElementSelector = '#left-topNavigation-container .VuetifyApp .v-application';
-      const $parentDialog = $(parentElementSelector);
-      if ($parentDialog.length) {
-        this.parentDialogSelector = parentElementSelector;
-      } else {
-        if ($('#left-topNavigation-container').length) {
-          const directionClass = eXo.env.portal.orientation === 'rtl' && 'v-application--is-rtl' || 'v-application--is-ltr';
-          $('#left-topNavigation-container').html(`
-              <div class="VuetifyApp">
-                <div data-app="true" class="v-application ${directionClass} transparent theme--light">
-                </div>
-              </div>`);
-          this.parentDialogSelector = parentElementSelector;
-        }
-      }
-    }
-
     const search = document.location.search.substring(1);
     if (search) {
       const parameters = JSON.parse(

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
@@ -64,7 +64,7 @@
           :current-space="currentSpace"
           :conference-provider="conferenceProvider"
           class="my-auto"
-          icon-class="me-10"/>
+          icon-class="me-10" />
         <div class="d-flex flex-row">
           <v-flex class="flex-grow-0">
             <i class="uiIconDescription darkGreyIcon uiIcon32x32 my-3 me-11"></i>
@@ -76,7 +76,7 @@
             :placeholder="$t('agenda.descriptionPlaceholder')"
             :max-length="eventDescriptionTextLength"
             :tag-enabled="false"
-            class="pt-2 width-full"/>
+            class="pt-2 width-full" />
         </div>
       </div>
       <div class="d-none d-md-flex flex-column mx-5 event-form-body-divider ">

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormConference.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormConference.vue
@@ -1,17 +1,22 @@
 <template>
   <div class="d-flex flex-row">
-    <v-icon :class="`darkGreyIcon my-auto ${this.iconClass} mt-4`" size="32px" v-if="!isMobile">fa-video</v-icon>
+    <v-icon
+      :class="`darkGreyIcon my-auto ${this.iconClass} mt-4`"
+      size="32px"
+      v-if="!isMobile">
+      fa-video
+    </v-icon>
     <template v-if="isConferenceEnabled">
       <template v-if="eventConference">
         <span :class="`${this.marginClass} mx-0 webconference-event-span`" v-if="eventConferenceUrl && this.conferenceProvider.canModifyEventUrl">
           <input
-              id="eventCallURL"
-              ref="eventCallURL"
-              v-model="conferenceURL"
-              :placeholder="$t('agenda.webConferenceURL')"
-              type="text"
-              name="webConferenceEvent"
-              class="ignore-vuetify-classes webconference-event-input mb-0 max-width-fit">
+            id="eventCallURL"
+            ref="eventCallURL"
+            v-model="conferenceURL"
+            :placeholder="$t('agenda.webConferenceURL')"
+            type="text"
+            name="webConferenceEvent"
+            class="ignore-vuetify-classes webconference-event-input mb-0 max-width-fit">
           <div class="flex-row grey--text">
             <i class="fas fa-exclamation-triangle primary--text"></i>
             {{ $t('agenda.webConferenceURL.warning') }}
@@ -42,7 +47,6 @@
             mdi-close
           </v-icon>
         </v-btn>
-
       </template>
       <v-btn
         v-else
@@ -54,14 +58,14 @@
     </template>
     <template v-else>
       <span :class="`${this.marginClass} mx-0 webconference-event-span-without-cross`">
-      <input
-        id="eventCallURL"
-        ref="eventCallURL"
-        v-model="conferenceURL"
-        :placeholder="$t('agenda.webConferenceURL')"
-        type="text"
-        name="webConferenceEvent"
-        class="ignore-vuetify-classes webconference-event-input max-width-fit">
+        <input
+          id="eventCallURL"
+          ref="eventCallURL"
+          v-model="conferenceURL"
+          :placeholder="$t('agenda.webConferenceURL')"
+          type="text"
+          name="webConferenceEvent"
+          class="ignore-vuetify-classes webconference-event-input max-width-fit">
       </span>
     </template>
   </div>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -68,7 +68,7 @@
             :settings="settings"
             :current-space="currentSpace"
             :conference-provider="conferenceProvider"
-            icon-class="mx-3"/>
+            icon-class="mx-3" />
           <div class="d-flex flex-row">
             <v-flex class="flex-grow-0">
               <i class="uiIconGroup darkGreyIcon uiIcon32x32 mt-4 mx-3"></i>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
@@ -81,7 +81,7 @@
           :event="event"
           :settings="settings"
           :current-space="currentSpace"
-          :conference-provider="conferenceProvider"/>
+          :conference-provider="conferenceProvider" />
         <label class="font-weight-bold my-2">
           {{ $t('agenda.participants') }}
         </label>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventIcs.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventIcs.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <div class="d-flex justify-center">
-      <v-btn outlined color="primary"
+      <v-btn
+        outlined
+        color="primary"
         class="pl-2 pr-2 text-body-1 btn border-radius v-chip v-chip--outlined theme--light primary primary--text mt-4 mb-2"
         :aria-label="$t('agenda.icsbutton')"
         :title="$t('agenda.icsbutton')"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="event-details-body overflow-auto flex-grow-1 d-flex flex-column flex-md-row pa-4 mt-5">
     <div class="flex-grow-1 flex-shrink-0 event-details-body-left " :class="{ 'd-flex' : !isMobile }">
-      <div class ="full-width" :class="{'mx-auto' : isMobile}">
+      <div class="full-width" :class="{'mx-auto' : isMobile}">
         <div class="event-date align-center d-flex pb-5">
           <i class="uiIconDatePicker darkGreyIcon uiIcon32x32 pe-5"></i>
           <div class="d-inline-flex">
@@ -125,7 +125,7 @@
       <v-divider vertical class="event-details-body-divider" />
     </div>
     <div class="flex-grow-1 flex-shrink-0 d-flex event-details-body-right">
-      <div class="mr-1 width-full" >
+      <div class="mr-1 width-full">
         <agenda-event-attendees
           ref="agendaAttendees"
           :event="event" />
@@ -137,13 +137,13 @@
             :connectors="connectors"
             :class="!isAcceptedEvent && 'agenda-hidden-connectors'"
             class="mt-4 mr-auto width-full"
-            @download-ics="downloadICS"/>
+            @download-ics="downloadICS" />
           <agenda-ics
             v-if="addToMyAgenda && !connectedConnector"
             :settings="settings"
             :event="event"
             :connectors="enabledconnectors"
-            @download-ics="downloadICS"/>
+            @download-ics="downloadICS" />
         </div>
       </div>
     </div>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorContemporaryEvents.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorContemporaryEvents.vue
@@ -6,15 +6,25 @@
           <div class="text-no-wrap text-truncate font-weight-bold text-title-color">
             {{ $t('agenda.personalCalendar') }}
           </div>
-          <div v-if="!connectedConnector" class="text-right flex-grow-1" @click="openPersonalCalendarDrawer"
-               :title="$t('agenda.connectYourPersonalAgenda')"
-               :aria-label="$t('agenda.connectYourPersonalAgenda')">
+          <div
+            v-if="!connectedConnector"
+            class="text-right flex-grow-1"
+            @click="openPersonalCalendarDrawer"
+            :title="$t('agenda.connectYourPersonalAgenda')"
+            :aria-label="$t('agenda.connectYourPersonalAgenda')">
             <v-icon class="uiIcon20x20 clickable" depressed>
               fa-external-link-alt
             </v-icon>
           </div>
-          <div v-else class="text-right flex-grow-1" @click="downloadICS">
-            <v-icon class="uiIcon20x20 clickable" depressed :aria-label="$t('agenda.icsbutton')" :title="$t('agenda.icsbutton')">
+          <div
+            v-else
+            class="text-right flex-grow-1"
+            @click="downloadICS">
+            <v-icon
+              class="uiIcon20x20 clickable"
+              depressed
+              :aria-label="$t('agenda.icsbutton')"
+              :title="$t('agenda.icsbutton')">
               fa-calendar-plus
             </v-icon>
           </div>
@@ -25,7 +35,7 @@
             tile
             class="me-1"
             size="16">
-          <img :src="connectedConnectorAvatar">
+            <img :src="connectedConnectorAvatar">
           </v-avatar>
           <a
             v-if="connectedConnector"


### PR DESCRIPTION
Prior to this change, when the Sidebar is stickied, then the dialog is displayed under the Sidebar drawer. This change ensures to display the Event dialog upon all applications in the page once displayed.

At the same time, this will run `npm run lint` in order to automatically fix Vue transpilation warnings.

Resolves Meeds-io/MIPs#175