### PR TITLE
fix: Event description char limit issue - EXO-77266.

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventForm.vue
@@ -152,7 +152,7 @@ export default {
       return this.event && this.event.description || '';
     },
     eventDescriptionValid() {
-      return this.eventDescription.length <= 1300;
+      return this.$utils.htmlToText(this.eventDescription).length <= 1300;
     },
     eventDateOptions() {
       return this.event && this.event.dateOptions || [];


### PR DESCRIPTION
Before this change, when create event having valid title and space in description with 1000 char content, Event can never be saved. To fix this problem, use this..htmlToText to convert HTML description content to plain text. After this change, event is saved as char limit isn't yet reached.