### PR TITLE
fix: conflict event drawer issue - EXO-77391.

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -1,6 +1,9 @@
 @import "./variables.less";
 
 .VuetifyApp {
+  .conflictEventsDrawer.layout-drawer{
+    z-index: 1060 !important;
+  }
 
   .v-current-time.today {
     height: 2px;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaDateOptionConflictDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaDateOptionConflictDrawer.vue
@@ -1,6 +1,7 @@
 <template>
   <exo-drawer
     ref="conflictEventsDrawer"
+    class="conflictEventsDrawer"
     right>
     <template slot="title">
       {{ $t('agenda.schedulingConflict') }}


### PR DESCRIPTION
Before this change, when click to open the conflictEventsDrawer drawer, nothing is displayed. To fix this problem, increase the z-index of this drawer. After this change, this drawer is displayed.