### PR TITLE
fix: Web conference event is not created if the event participant includes a deactivated user - EXO-77085

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
@@ -56,7 +56,7 @@ function createConference(event, conference) {
   // FIXME : Web conferencing uses userName for users and Space Identity id for spaces
   return getAllIdentities(event.attendees)
     .then(identities => {
-      const participants = identities.filter(identity => identity && identity.providerId === 'organization').map(identity => identity.remoteId);
+      const participants = identities.filter(identity => identity && identity.providerId === 'organization' && identity?.profile?.dataEntity?.enabled).map(identity => identity.remoteId);
       const spaces = identities.filter(identity => identity && identity.providerId === 'space').map(identity => identity.remoteId);
       const startDate = new Date(event.startDate);
       const endDate = event.endDate && new Date(event.endDate) || event.recurrence && event.recurrence.until && new Date(event.recurrence.until) || null;


### PR DESCRIPTION
Prior to this change web conference event was not created if the event participant includes a deactivated user, this change is going to exclude the deactivated users from the web conference event participant.