### PR TITLE
fix: Fix agenda events gamification contributions urls redirection - EXO-77472

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventAttendeeGamificationIntegrationListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventAttendeeGamificationIntegrationListener.java
@@ -57,7 +57,7 @@ public class AgendaEventAttendeeGamificationIntegrationListener extends Listener
         try {
           Map<String, String> gam = new HashMap<>();
           gam.put("ruleTitle", GAMIFICATION_REPLY_TO_EVENT_RULE_TITLE);
-          gam.put("object", eventURL);
+          gam.put("objectId", eventURL);
           gam.put("senderId", String.valueOf(earnerId)); // matches the
                                                          // gamification's
                                                          // earner id

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventGamificationIntegrationListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/AgendaEventGamificationIntegrationListener.java
@@ -81,7 +81,7 @@ public class AgendaEventGamificationIntegrationListener extends Listener<Object,
           try {
             Map<String, String> gam = new HashMap<>();
             gam.put("ruleTitle", ruleTitle);
-            gam.put("object", eventURL);
+            gam.put("objectId", eventURL);
             gam.put("senderId", String.valueOf(earnerId)); // matches the
                                                            // gamification's
                                                            // earner id
@@ -95,7 +95,7 @@ public class AgendaEventGamificationIntegrationListener extends Listener<Object,
           try {
             Map<String, String> gam = new HashMap<>();
             gam.put("ruleTitle", ruleTitle);
-            gam.put("object", eventURL);
+            gam.put("objectId", eventURL);
             gam.put("senderId", String.valueOf(earnerId)); // matches the
                                                            // gamification's
                                                            // earner id
@@ -126,7 +126,7 @@ public class AgendaEventGamificationIntegrationListener extends Listener<Object,
         try {
           Map<String, String> gam = new HashMap<>();
           gam.put("ruleTitle", ruleTitle);
-          gam.put("object", eventURL);
+          gam.put("objectId", eventURL);
           gam.put("senderId", String.valueOf(earnerId)); // matches the
                                                          // gamification's
                                                          // earner id


### PR DESCRIPTION

Prior to this change, agenda events gamification contributions are not redirected to the corresponding events urls, this is due to the "objectId" param not set and send correctly from agenda listeners AgendaEventAttendeeGamificationIntegrationListener and AgendaEventGamificationIntegrationListener to the generic gamification listener GamificationGenericListener. After this commit, we ensure to set correctly the "objectId" param with the event url in order to perform the good redirection of the gamification contributions.