### PR TITLE
fix: repeat event frequency customize drawer not displayed until event canceled or created - EXO-77608

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -5,6 +5,10 @@
     z-index: 1060 !important;
   }
 
+  .customRecurrentEventDrawer.layout-drawer{
+    z-index: 1060 !important;
+  }
+  
   .v-current-time.today {
     height: 2px;
     width: 100%;


### PR DESCRIPTION
Before this change, when click to open the customRecurrentEventDrawer drawer, nothing is displayed. To fix this problem, increase the z-index of this drawer. After this change, this drawer is displayed.

(cherry picked from commit a08f4abfff489a5cdfa1b81cafe2aa3d3c96c9f7)