### PR TITLE
fix: Event title display if long - EXO-76605

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -438,10 +438,7 @@
     > * {
       max-width: 50%;
     }
-    .event-title {
-      font-weight: bold;
-      display: inline-block;
-    }
+    
     .spaceAvatar > * {
       max-width: 100%;
     }

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetailsToolbar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetailsToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row class="event-details-header d-flex align-center flex-nowrap text-left col-12 mx-0">
-    <v-col :title="event.summary" class="event-title text-title text-truncate col-auto ps-4 mx-2">
+    <v-col :title="event.summary" class="text-title text-truncate-2 col-auto py-0 ps-4 mx-2">
       {{ event.summary }}
     </v-col>
     <v-col class="flex-grow-0 flex-shrink-0 px-0 mx-2">


### PR DESCRIPTION
Before this change, when create on spacex event having long title and display created event details then check the display of event synchronized with Google, the Google events are longer than the page. To fix this problem, change the text-truncute class to text-truncute-2 and remove the event-title class. After this change, the title is displayed in 2 lines and if longer we display an ellipsis at the end.