### PR TITLE
fix: Event title display if long - EXO-76605 .

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -438,7 +438,10 @@
     > * {
       max-width: 50%;
     }
-    
+    .event-title {
+      font-weight: bold;
+      display: inline-block;
+    }
     .spaceAvatar > * {
       max-width: 100%;
     }
@@ -837,7 +840,7 @@
     .event-details {
       .event-details-body {
         .event-details-body-right {
-          min-width: 384px !important;
+          width: 384px !important;
         }
         .event-details-body-left {
           min-width: ~"calc(100% - 424px)";

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetailsToolbar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventDetailsToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row class="event-details-header d-flex align-center flex-nowrap text-left col-12 mx-0">
-    <v-col :title="event.summary" class="text-title text-truncate-2 col-auto py-0 ps-4 mx-2">
+    <v-col :title="event.summary" class="event-title text-title text-truncate col-auto ps-4 mx-2">
       {{ event.summary }}
     </v-col>
     <v-col class="flex-grow-0 flex-shrink-0 px-0 mx-2">

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorRemoteEventItem.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorRemoteEventItem.vue
@@ -8,7 +8,7 @@
     <p
       :title="remoteEvent.summary"
       :class="textClass"
-      class="text-truncate my-auto ms-2 caption font-weight-bold">
+      class="text-truncate-2 my-auto ms-2 caption font-weight-bold">
       {{ remoteEvent.summary }}
     </p>
     <template v-if="!displayEventDate">


### PR DESCRIPTION
Before this change, when create on spacex event having long title and display created event details then check the display of event synchronized with Google, the Google events are longer than the page. To fix this problem, change the text-truncute class to text-truncute-2 and the min-widht property of the event-details-body-right class to width remove the event-title class then revert the commit of the TASK-76605 branch. After this change, the title is displayed in 2 lines and if longer we display an ellipsis at the end.