### PR TITLE
fix: Synchronized events title display not ok if long - EXO-76605

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -840,7 +840,7 @@
     .event-details {
       .event-details-body {
         .event-details-body-right {
-          min-width: 384px !important;
+          width: 384px !important;
         }
         .event-details-body-left {
           min-width: ~"calc(100% - 424px)";

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorRemoteEventItem.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/remote-event/AgendaConnectorRemoteEventItem.vue
@@ -8,7 +8,7 @@
     <p
       :title="remoteEvent.summary"
       :class="textClass"
-      class="text-truncate my-auto ms-2 caption font-weight-bold">
+      class="text-truncate-2 my-auto ms-2 caption font-weight-bold">
       {{ remoteEvent.summary }}
     </p>
     <template v-if="!displayEventDate">


### PR DESCRIPTION
Before this change, checking the display of event synchronized with Google, the Google events are longer than the page. 
To fix this problem, change the text-truncute class to text-truncute-2 and the min-widht property of the event-details-body-right class to width remove the event-title class . 
After this change, the title of synchronized event is displayed in 2 lines and if longer we display an ellipsis at the end.

(cherry picked from commit 5b3cc15628846339f63e6a44e131a0fbf463c954)