### PR TITLE
fix: Agenda's connect calendar drawer issue - EXO-77950

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -1,11 +1,9 @@
 @import "./variables.less";
 
 .VuetifyApp {
-  .conflictEventsDrawer.layout-drawer{
-    z-index: 1060 !important;
-  }
-
-  .customRecurrentEventDrawer.layout-drawer{
+  .layout-drawer.conflictEventsDrawer,
+  .layout-drawer.agendaConnectorsDrawer,
+  .layout-drawer.customRecurrentEventDrawer {
     z-index: 1060 !important;
   }
   


### PR DESCRIPTION
Before this change, when open event details and click on Synchronize your events with your personal calendar, Connect drawer is displayed only if event display is closed. To fix this problem, increase the z-index of this drawer. After this change, this drawer is displayed.

(cherry picked from commit 48da43bb95426ada68d013b287d5dba777a321ec) (cherry picked from commit d0e1e5c044ddd836abdd056a96cd027cfd4e7cb9)