### PR TITLE
Fix: UI glitch when opening an agenda using Mobile - EXO-77995

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -677,7 +677,6 @@
 }
 
 .agenda-mobile-header {
-  z-index: 999;
   position: relative;
 }
 .agenda-timeline {


### PR DESCRIPTION
Before this change, when accessing the platform via mobile, open the agenda and then open the sidebar, the agenda is overriding the display of the sidebar. To fix this problem, remove the z-index applied to the sidebar. After this change, the sidebar is visible regardless of the page being viewed, and the agenda remains displayed behind it.

(cherry picked from commit c857b30926e09d1ea7ee4469b6bd425b03443cb8)