### PR TITLE
fix: Edit reminders icon not displayed in event details - EXO-78236

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -3,7 +3,8 @@
 .VuetifyApp {
   .layout-drawer.conflictEventsDrawer,
   .layout-drawer.agendaConnectorsDrawer,
-  .layout-drawer.customRecurrentEventDrawer {
+  .layout-drawer.customRecurrentEventDrawer,
+  .layout-drawer.agendaEventRemindersDrawer {
     z-index: 1060 !important;
   }
   

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventRemindersDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventRemindersDrawer.vue
@@ -1,6 +1,7 @@
 <template>
   <exo-drawer
     ref="drawer"
+    class="agendaEventRemindersDrawer"
     :confirm-close="confirmClose"
     :confirm-close-labels="confirmCloseLabels"
     body-classes="hide-scroll decrease-z-index-more"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
@@ -81,7 +81,7 @@
             transparent
             class="mb-auto border-box-sizing"
             @click="$refs.reminders.open()">
-            <i class="uiIconEditInfo uiIcon16x16 darkGreyIcon pt-2"></i>
+            <i class="uiIconEdit uiIcon16x16 darkGreyIcon pt-2"></i>
           </v-btn>
         </div>
         <div v-if="isConferenceEnabled" class="event-conference flex d-flex flex-grow-0 flex-shrink-1 pb-5">


### PR DESCRIPTION
Before this change, when open event details, Edit reminders button not displayed + once it position clicked, the drawer is displayed after closing event. To fix this problem, increase the z-index of this drawer and change icon from uiIconEditInfo to uiIconEdit. After this change, this drawer and the button are displayed.

(cherry picked from commit 09f4acc41ab381b692fc9fd3e0153ea2036c8470)