### PR TITLE
fix: validation options are missing in event poll - EXO-78308

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaEventDateOptionVote.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaEventDateOptionVote.vue
@@ -10,7 +10,12 @@
         @change="$emit('change', vote)" />
       <template v-else>
         <span v-if="!hasVoted"></span>
-        <i v-else-if="vote" class="uiIcon py-1 uiIconColorValidate"></i>
+        <v-icon
+          v-else-if="vote"
+          :size="18"
+          class="success--text icon-default-size py-1">
+          fas fa-check
+        </v-icon>
         <i v-else class="uiIcon py-1 uiIconColorError"></i>
       </template>
     </div>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaEventDateOptionVoter.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaEventDateOptionVoter.vue
@@ -32,7 +32,11 @@
           transparent
           class="ma-auto border-box-sizing"
           @click="$root.$emit('agenda-date-poll-change-vote')">
-          <i class="uiIconEditInfo uiIcon16x16 darkGreyIcon pb-2"></i>
+          <v-icon
+            :size="16"
+            class="icon-default-color icon-default-size pb-2">
+            fas fa-edit
+          </v-icon>
         </v-btn>
       </v-card>
     </th>


### PR DESCRIPTION
Before this change, when as user1 create event poll containing two alternative dates and invite a user and accept both options then check responses, validation and edit icons are missing. To fix this problem, change the edit button icon and the validation icon to v-icon. After this change, the validation and edit icons are displayed correctly.