### PR TITLE
feat: Add Agenda Event Content Link Extension as Drawer - EXO-79046 -EXO-79053 - eXIP-11

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/plugin/AgendaEventAclPlugin.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/plugin/AgendaEventAclPlugin.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.plugin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.agenda.model.Event;
+import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.portal.plugin.AclPlugin;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class AgendaEventAclPlugin implements AclPlugin {
+
+  public static final String OBJECT_TYPE = "agendaEvent";
+
+  @Autowired
+  private AgendaEventService agendaEventService;
+
+  @Autowired
+  private PortalContainer    container;
+
+  @Autowired
+  private IdentityManager    identityManager;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(UserACL.class).addAclPlugin(this);
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean hasPermission(String objectId,
+                               String permissionType,
+                               Identity identity) {
+    Event event = agendaEventService.getEventById(Long.parseLong(objectId));
+    if (event == null || identity == null) {
+      return false;
+    }
+    return switch (permissionType) {
+    case VIEW_PERMISSION_TYPE: {
+      yield agendaEventService.canAccessEvent(event, getUserIdentityId(identity.getUserId()));
+    }
+    case EDIT_PERMISSION_TYPE, DELETE_PERMISSION_TYPE: {
+      yield agendaEventService.canUpdateEvent(event, getUserIdentityId(identity.getUserId()));
+    }
+    default:
+      yield false;
+    };
+  }
+
+  private long getUserIdentityId(String username) {
+    return Long.parseLong(identityManager.getOrCreateUserIdentity(username)
+                                         .getId());
+  }
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/plugin/AgendaEventContentLinkPlugin.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/plugin/AgendaEventContentLinkPlugin.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.plugin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.jsoup.Jsoup;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.agenda.model.Event;
+import org.exoplatform.agenda.model.EventSearchResult;
+import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.social.cms.model.ContentLinkExtension;
+import io.meeds.social.cms.model.ContentLinkSearchResult;
+import io.meeds.social.cms.plugin.ContentLinkPlugin;
+import io.meeds.social.cms.service.ContentLinkPluginService;
+
+import jakarta.annotation.PostConstruct;
+import lombok.SneakyThrows;
+
+@Component
+public class AgendaEventContentLinkPlugin implements ContentLinkPlugin {
+
+  public static final String                OBJECT_TYPE = AgendaEventAclPlugin.OBJECT_TYPE;
+
+  private static final String               TITLE_KEY   = "contentLink.agendaEvent";
+
+  private static final String               ICON        = "fa fa-calendar-day";
+
+  private static final String               COMMAND     = "event";
+
+  private static final ContentLinkExtension EXTENSION   = new ContentLinkExtension(OBJECT_TYPE,
+                                                                                   TITLE_KEY,
+                                                                                   ICON,
+                                                                                   COMMAND,
+                                                                                   true);
+
+  @Autowired
+  private PortalContainer                   container;
+
+  @Autowired
+  private UserACL                           userAcl;
+
+  @Autowired
+  private IdentityManager                   identityManager;
+
+  @Autowired
+  private AgendaEventService                agendaEventService;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(ContentLinkPluginService.class).addPlugin(this);
+  }
+
+  @Override
+  public ContentLinkExtension getExtension() {
+    return EXTENSION;
+  }
+
+  @Override
+  @SneakyThrows
+  public List<ContentLinkSearchResult> search(String keyword, Identity identity, Locale locale, int offset, int limit) {
+    if (userAcl.isAnonymousUser(identity)) {
+      return Collections.emptyList();
+    }
+    List<EventSearchResult> events = agendaEventService.search(getUserIdentityId(identity.getUserId()),
+                                                               null,
+                                                               keyword,
+                                                               offset,
+                                                               limit);
+    return CollectionUtils.isEmpty(events) ? Collections.emptyList() :
+                                           events.stream()
+                                                 .map(this::toContentLink)
+                                                 .toList();
+  }
+
+  @Override
+  public String getContentTitle(String objectId, Locale locale) {
+    Event event = agendaEventService.getEventById(Long.parseLong(objectId));
+    return event == null ? null : event.getSummary();
+  }
+
+  private ContentLinkSearchResult toContentLink(EventSearchResult event) {
+    if (event == null) {
+      return null;
+    } else {
+      return new ContentLinkSearchResult(EXTENSION.getObjectType(),
+                                         String.valueOf(event.getId()),
+                                         Jsoup.parse(event.getSummary()).text(),
+                                         EXTENSION.getIcon(),
+                                         EXTENSION.isDrawer());
+    }
+  }
+
+  private long getUserIdentityId(String username) {
+    return Long.parseLong(identityManager.getOrCreateUserIdentity(username)
+                                         .getId());
+  }
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/plugin/AgendaEventPermanentLinkPlugin.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/plugin/AgendaEventPermanentLinkPlugin.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.plugin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.services.security.Identity;
+
+import io.meeds.portal.permlink.model.PermanentLinkObject;
+import io.meeds.portal.permlink.plugin.PermanentLinkPlugin;
+import io.meeds.portal.permlink.service.PermanentLinkService;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class AgendaEventPermanentLinkPlugin implements PermanentLinkPlugin {
+
+  public static final String      OBJECT_TYPE = AgendaEventAclPlugin.OBJECT_TYPE;
+
+  public static final String      URL_FORMAT  = "/portal/%s/agenda?eventId=%s";
+
+  @Autowired
+  private UserACL                 userAcl;
+
+  @Autowired
+  private UserPortalConfigService portalConfigService;
+
+  @Autowired
+  private PortalContainer         container;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(PermanentLinkService.class).addPlugin(this);
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean canAccess(PermanentLinkObject object, Identity identity) throws ObjectNotFoundException {
+    return userAcl.hasAccessPermission(OBJECT_TYPE, object.getObjectId(), identity);
+  }
+
+  @Override
+  public String getDirectAccessUrl(PermanentLinkObject object) throws ObjectNotFoundException {
+    return String.format(URL_FORMAT, portalConfigService.getMetaPortal(), object.getObjectId());
+  }
+
+}

--- a/agenda-webapps/pom.xml
+++ b/agenda-webapps/pom.xml
@@ -10,6 +10,12 @@
   <name>eXo Agenda - Application</name>
   <dependencies>
     <dependency>
+      <groupId>io.meeds.social</groupId>
+      <artifactId>social-component-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.meeds.platform-ui</groupId>
       <artifactId>platform-ui-skin</artifactId>
       <classifier>sources</classifier>

--- a/agenda-webapps/src/main/java/org/exoplatform/agenda/AgendaApplication.java
+++ b/agenda-webapps/src/main/java/org/exoplatform/agenda/AgendaApplication.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.agenda;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import io.meeds.spring.AvailableIntegration;
+import io.meeds.spring.kernel.PortalApplicationContextInitializer;
+
+@SpringBootApplication(scanBasePackages = {
+  AgendaApplication.MODULE_NAME,
+  AvailableIntegration.KERNEL_MODULE,
+  AvailableIntegration.JPA_MODULE,
+  AvailableIntegration.WEB_MODULE,
+}, exclude = {
+  LiquibaseAutoConfiguration.class,
+})
+@EnableJpaRepositories(basePackages = AgendaApplication.MODULE_NAME)
+@PropertySource("classpath:application.properties")
+@PropertySource("classpath:application-common.properties")
+public class AgendaApplication extends PortalApplicationContextInitializer {
+
+  public static final String MODULE_NAME = "org.exoplatform.agenda";
+
+}

--- a/agenda-webapps/src/main/resources/locale/portlet/ContentLink_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/ContentLink_en.properties
@@ -1,0 +1,1 @@
+contentLink.agendaEvent=Event

--- a/agenda-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -254,4 +254,16 @@
       <module>extensionRegistry</module>
     </depends>
   </module>
+
+  <module>
+    <name>agendaEventContentLinkExtension</name>
+    <load-group>contentLinkGRP</load-group>
+    <script>
+      <path>/js/agendaEventContentLinkExtension.bundle.js</path>
+    </script>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
 </gatein-resources>

--- a/agenda-webapps/src/main/webapp/WEB-INF/web.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,7 @@
     <url-pattern>*.css</url-pattern>
     <url-pattern>*.js</url-pattern>
     <url-pattern>*.html</url-pattern>
+    <url-pattern>/i18n/*</url-pattern>
     <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
@@ -179,6 +179,7 @@ export default {
         }
       }
     });
+    this.$root.$on('agenda-event-details-by-id', this.openEventById);
     this.$root.$on('agenda-event-details', agendaEvent => {
       if (agendaEvent.id) {
         this.openEventDetails(agendaEvent.id);

--- a/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app class="agenda-application border-box-sizing" flat>
-    <template v-if="settingsLoaded">
+    <template v-if="settingsLoaded && !hideApp">
       <v-main v-if="isMobile" class="application-body pt-2 px-1">
         <agenda-mobile-header
           :current-space="currentSpace"
@@ -86,6 +86,10 @@ export default {
       type: String,
       // allEvents, declinedEvent or myEvents
       default: () => 'myEvents',
+    },
+    hideApp: {
+      type: Boolean,
+      default: false,
     },
   },
   data: () => ({

--- a/agenda-webapps/src/main/webapp/vue-app/content-link/extensions.js
+++ b/agenda-webapps/src/main/webapp/vue-app/content-link/extensions.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const appId = 'agendaEvent-content-link';
+
+export function init() {
+  document.addEventListener('content-link-agendaEvent-drawer', openAgendaEventDrawer);
+}
+
+function openAgendaEventDrawer(event) {
+  window.require(['SHARED/eXoVueI18n', 'PORTLET/agenda/Agenda'], exoi18n => initAgenda(exoi18n, event.detail));
+}
+
+async function initAgenda(exoi18n, eventId) {
+  if (!document.querySelector(`#${appId}`)) {
+    const parent = document.createElement('div');
+    parent.id = appId;
+    document.querySelector('#vuetify-apps').appendChild(parent);
+    await Promise.all([
+      initAgendaApp(exoi18n),
+      Vue.prototype.$utils.importSkin('agenda', 'Agenda'),
+    ]);
+  }
+  document.dispatchEvent(new CustomEvent('content-link-agendaEvent-drawer-open', {detail: eventId}));
+}
+
+export function initAgendaApp(exoi18n) {
+  const lang = eXo.env.portal.language;
+  const url = `/agenda/i18n/locale.portlet.Agenda?lang=${lang}`;
+  return new Promise(resolve => exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+    Vue.createApp({
+      template: `<agenda id="${appId}" event-type="allEvents" hide-app />`,
+      created() {
+        document.addEventListener('content-link-agendaEvent-drawer-open', this.openAgendaEvent);
+      },
+      mounted() {
+        resolve();
+      },
+      beforeDestroy() {
+        document.removeEventListener('content-link-agendaEvent-drawer-open', this.openAgendaEvent);
+      },
+      methods: {
+        openAgendaEvent(event) {
+          this.$root.$emit('agenda-event-details-by-id', event.detail);
+        }
+      },
+      vuetify: Vue.prototype.vuetifyOptions,
+      i18n
+    }, `#${appId}`, 'Agenda Content Link');
+  }).finally(() => {
+    Vue.prototype.$utils.includeExtensions('VisioConnector');
+    Vue.prototype.$utils.includeExtensions('ConnectorsExtensions');
+  }));
+}

--- a/agenda-webapps/webpack.prod.js
+++ b/agenda-webapps/webpack.prod.js
@@ -31,7 +31,7 @@ const config = {
     agendaAdminSettings: './src/main/webapp/vue-app/agenda-admin-settings/main.js',
     agendaNotificationsExtension: './src/main/webapp/vue-app/agenda-notifications/main.js',
     engagementCenterExtensions: './src/main/webapp/vue-app/engagementCenterExtensions/extensions.js',
-
+    agendaEventContentLinkExtension: './src/main/webapp/vue-app/content-link/extensions.js',
   },
   output: {
     path: path.join(__dirname, 'target/agenda/'),

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -105,4 +105,14 @@ files: [
     "escape_special_characters": 0,
     "escape_quotes" : 0,
   },
+  {
+    "source" : "/agenda-webapps/src/main/resources/locale/portlet/ContentLink_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {YML_CROWDIN_LANGUAGES_ARG},
+    "dest" : "add__ons/agenda/ContentLink.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
 ]


### PR DESCRIPTION
This change will allow to reference an agenda Event inside Rich Editor Contents like article, notes, activity, task...
To do this an ACL Plugin, Permanent Link Plugin and Content Link Plugin has been added.
In addition, a JS extension has been added to allow displaying the agenda Event in the current page without changing Page.