### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/agenda-api/pom.xml
+++ b/agenda-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.1.x-SNAPSHOT</version>
+    <version>7.1.x-mips-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-api</artifactId>
   <name>eXo Agenda - API</name>

--- a/agenda-packaging/pom.xml
+++ b/agenda-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.1.x-SNAPSHOT</version>
+    <version>7.1.x-mips-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-packaging</artifactId>
   <packaging>pom</packaging>

--- a/agenda-services/pom.xml
+++ b/agenda-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.1.x-SNAPSHOT</version>
+    <version>7.1.x-mips-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-services</artifactId>
   <name>eXo Agenda - Services</name>

--- a/agenda-services/src/main/java/org/exoplatform/agenda/dao/EventDAO.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/dao/EventDAO.java
@@ -120,6 +120,7 @@ public class EventDAO extends GenericDAOJPAImpl<EventEntity, Long> {
 
     if (eventEntity.getRecurrence() != null) {
       this.eventRecurrenceDAO.delete(eventEntity.getRecurrence());
+      eventEntity.setRecurrence(null);
     }
 
     delete(eventEntity);

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventAttendeeServiceImpl.java
@@ -411,7 +411,7 @@ public class AgendaEventAttendeeServiceImpl implements AgendaEventAttendeeServic
           attendeeStorage.saveEventAttendee(eventAttendee, eventId);
         }
       }
-      attendee = new EventAttendee(identityId, eventId, identityId, occurrenceId, null, response);
+      attendee = new EventAttendee(0, eventId, identityId, occurrenceId, null, response);
       attendeeStorage.saveEventAttendee(attendee, eventId);
     }
 

--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaEventReminderServiceImpl.java
@@ -186,6 +186,7 @@ public class AgendaEventReminderServiceImpl implements AgendaEventReminderServic
     } else {
       for (EventReminder eventReminder : reminders) {
         eventReminder.setId(0);
+        eventReminder.setEventId(eventId);
         eventReminder.setFromOccurrenceId(occurrenceId);
         eventReminder.setUntilOccurrenceId(null);
       }
@@ -308,6 +309,7 @@ public class AgendaEventReminderServiceImpl implements AgendaEventReminderServic
         eventReminder = eventReminder.clone();
 
         ZonedDateTime reminderDate = computeReminderDateTime(event, eventReminder);
+        eventReminder.setId(0);
         eventReminder.setDatetime(reminderDate);
         eventReminder.setReceiverId(identityId);
         eventReminder.setEventId(eventId);

--- a/agenda-services/src/main/java/org/exoplatform/agenda/storage/AgendaCalendarStorage.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/storage/AgendaCalendarStorage.java
@@ -25,6 +25,7 @@ import org.exoplatform.agenda.dao.CalendarDAO;
 import org.exoplatform.agenda.entity.CalendarEntity;
 import org.exoplatform.agenda.model.Calendar;
 import org.exoplatform.agenda.util.Utils;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.listener.ListenerService;
 
 public class AgendaCalendarStorage {
@@ -74,6 +75,7 @@ public class AgendaCalendarStorage {
       return;
     }
     this.agendaEventStorage.deleteCalendarEvents(calendarId);
+    RequestLifeCycle.restartTransaction();
     calendarDAO.delete(calendarEntity);
     Utils.broadcastEvent(listenerService, "exo.agenda.calendar.deleted", fromEntity(calendarEntity), null);
   }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/EntityMapper.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/EntityMapper.java
@@ -95,7 +95,7 @@ public class EntityMapper {
 
   public static EventReminderEntity toEntity(EventReminder eventReminder) {
     EventReminderEntity eventReminderEntity = new EventReminderEntity();
-    eventReminderEntity.setId(eventReminder.getId());
+    eventReminderEntity.setId(eventReminder.getId() == 0 ? null : eventReminder.getId());
     eventReminderEntity.setBefore(eventReminder.getBefore());
     eventReminderEntity.setBeforeType(eventReminder.getBeforePeriodType());
     eventReminderEntity.setReceiverId(eventReminder.getReceiverId());
@@ -176,7 +176,7 @@ public class EntityMapper {
     TimeZone ical4jTimezone = Utils.getICalTimeZone(iCal4jZoneId);
 
     EventEntity eventEntity = new EventEntity();
-    eventEntity.setId(event.getId());
+    eventEntity.setId(event.getId() == 0 ? null : event.getId());
     eventEntity.setAllDay(event.isAllDay());
     eventEntity.setAvailability(event.getAvailability());
     eventEntity.setColor(event.getColor());
@@ -454,7 +454,7 @@ public class EntityMapper {
     // given by the user
     eventRecurrenceEntity.setStartDate(AgendaDateUtils.toDate(event.getStart()));
     eventRecurrenceEntity.setEndDate(AgendaDateUtils.toDate(event.getEnd()));
-    eventRecurrenceEntity.setId(recurrence.getId());
+    eventRecurrenceEntity.setId(recurrence.getId() == 0l ? null : recurrence.getId());
     return eventRecurrenceEntity;
   }
 
@@ -469,7 +469,7 @@ public class EntityMapper {
 
   public static EventAttendeeEntity toEntity(EventAttendee eventAttendee) {
     EventAttendeeEntity eventAttendeeEntity = new EventAttendeeEntity();
-    eventAttendeeEntity.setId(eventAttendee.getId());
+    eventAttendeeEntity.setId(eventAttendee.getId() == 0 ? null : eventAttendee.getId());
     eventAttendeeEntity.setIdentityId(eventAttendee.getIdentityId());
     eventAttendeeEntity.setResponse(eventAttendee.getResponse());
     eventAttendeeEntity.setFromOccurrenceId(AgendaDateUtils.toDate(eventAttendee.getFromOccurrenceId()));
@@ -489,7 +489,7 @@ public class EntityMapper {
 
   public static EventConferenceEntity toEntity(EventConference eventConference) {
     EventConferenceEntity eventConferenceEntity = new EventConferenceEntity();
-    eventConferenceEntity.setId(eventConference.getId());
+    eventConferenceEntity.setId(eventConference.getId() == 0 ? null : eventConference.getId());
     eventConferenceEntity.setAccessCode(eventConference.getAccessCode());
     eventConferenceEntity.setDescription(eventConference.getDescription());
     eventConferenceEntity.setPhone(eventConference.getPhone());

--- a/agenda-services/src/test/java/org/exoplatform/agenda/dao/EventDAOTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/dao/EventDAOTest.java
@@ -99,6 +99,7 @@ public class EventDAOTest extends TestCase {
       assertEquals(endDate, eventEntity.getEndDate());
     } finally {
       eventDAO.deleteCalendarEvents(calendarEntity.getId());
+      RequestLifeCycle.restartTransaction();
       calendarDAO.delete(calendarEntity);
     }
   }

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventReminderServiceTest.java
@@ -24,6 +24,8 @@ import java.util.*;
 
 import org.exoplatform.agenda.model.Calendar;
 import org.exoplatform.commons.api.notification.service.WebNotificationService;
+import org.exoplatform.container.component.RequestLifeCycle;
+
 import org.junit.Test;
 
 import org.exoplatform.agenda.constant.*;
@@ -248,8 +250,8 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
 
     long eventId = event.getId();
 
-    EventReminder upcomingEventsReminder = new EventReminder(5000l,
-                                                             10000l,
+    EventReminder upcomingEventsReminder = new EventReminder(0l,
+                                                             event.getId(),
                                                              testuser1Id,
                                                              5,
                                                              ReminderPeriodType.HOUR);
@@ -260,9 +262,9 @@ public class AgendaEventReminderServiceTest extends BaseAgendaEventTest {
     assertEquals(1, eventReminders.size());
 
     agendaEventService.saveEventExceptionalOccurrence(eventId, start.plusDays(4));
-
+    RequestLifeCycle.restartTransaction();
     agendaEventReminderService.saveUpcomingEventReminders(eventId, start.plusDays(5), upcomingEventsReminders, testuser1Id);
-
+    RequestLifeCycle.restartTransaction();
     Event exceptionalOccurrence = agendaEventService.saveEventExceptionalOccurrence(eventId, start.plusDays(10));
 
     assertNotNull(exceptionalOccurrence);

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -28,7 +28,7 @@ import java.util.*;
 
 import org.exoplatform.commons.api.notification.model.MessageInfo;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
-
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.mail.Attachment;
 import org.junit.Test;
 
@@ -2210,6 +2210,7 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
       assertNotNull(event);
     }
 
+    RequestLifeCycle.restartTransaction();
     agendaEventService.deleteEventById(eventId, Long.parseLong(testuser1Identity.getId()));
     AgendaEventModification eventModification = eventDeletionReference.get();
     assertNotNull(eventModification);

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/BaseAgendaEventTest.java
@@ -236,6 +236,7 @@ public abstract class BaseAgendaEventTest {
       agendaCalendarService.deleteCalendarById(spaceCalendar.getId());
       spaceCalendar = null;
     }
+    restartTransaction();
     if (calendar != null) {
       agendaCalendarService.deleteCalendarById(calendar.getId());
       calendar = null;

--- a/agenda-webapps/pom.xml
+++ b/agenda-webapps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.1.x-SNAPSHOT</version>
+    <version>7.1.x-mips-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-webapps</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>maven-exo-parent-pom</artifactId>
     <groupId>org.exoplatform</groupId>
-    <version>28-M02</version>
+    <version>28-mips-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.agenda</groupId>
   <artifactId>agenda-parent</artifactId>
-  <version>7.1.x-SNAPSHOT</version>
+  <version>7.1.x-mips-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Agenda - Parent POM</name>
   <description>eXo Agenda Addon</description>
@@ -27,7 +27,7 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.commons-exo.version>7.1.x-SNAPSHOT</org.exoplatform.commons-exo.version>
+    <org.exoplatform.commons-exo.version>7.1.x-mips-SNAPSHOT</org.exoplatform.commons-exo.version>
 
     <!-- ical4j dependencies -->
     <org.mnode.ical4j.version>3.2.19</org.mnode.ical4j.version>


### PR DESCRIPTION
This change will upgrade Hibernate to version 6.6 which introduced a bug fix (as explained in https://discourse.hibernate.org/t/instance-save-transient-before/10293/2) which makes some operations buggy when made in the same transaction. This change ensures to split operations to not hit such a problem.