### PR TITLE
fix: Agenda caldav connector drawer is opend on background - EXO-79620

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -8,6 +8,10 @@
     z-index: 1060 !important;
   }
   
+  #exchangeSettingsDrawer {
+    z-index: 1065 !important;
+  }
+  
   .v-current-time.today {
     height: 2px;
     width: 100%;


### PR DESCRIPTION
Before this change, when open personal settings then connect to personal caldav/exchange calendar and check display of drawers, caldav drawer to type password and username is opened on background. To fix this problem, add z-index equal to 1065. After this change, caldav drawer is opened on top.