### PR TITLE
fix: Events are displayed over date selector on PWA mobile app - EXO-79223 

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaEmptyTimeline.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaEmptyTimeline.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-sheet class="d-flex flex-column justify-center align-center fill-height" max-height="100%">
+  <v-sheet class="d-flex flex-column justify-center align-center fill-height z-index-one" max-height="100%">
     <v-icon
       color="secondary"
       size="60"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaMobileHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaMobileHeader.vue
@@ -8,7 +8,7 @@
       class="my-auto agenda-toolbar-left" />
     <date-picker
       v-model="periodStart"
-      class="d-flex flex-grow-1 ma-auto agenda-header-date-picker" />
+      class="d-flex flex-grow-1 ma-auto agenda-header-date-picker z-index-two" />
     <agenda-calendar-filter-button
       :current-space="currentSpace"
       :owner-ids="ownerIds" />


### PR DESCRIPTION
Before this change, when connect using PWA app on mobile device then create some events on current day in spaceA's agenda app and click on date selector, events are displayed over date card selector. To fix this problem, modify the z-indexes of each element. After this change, date card selector is displayed over events list.