### PR TITLE
fix: Fix event detail url from agenda event timeline gadget - EXO-79567

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
@@ -286,8 +286,8 @@ export default {
         agendaEvent.attendees = [];
       }
       this.event = agendaEvent;
-
-      let eventDetailsPath = `${window.location.pathname}`;
+      const spaceSiteKeyName = eXo.env.portal.siteKeyName.replace(/\//g, ':');
+      let eventDetailsPath = window.location.pathname.includes('spaces') ? `/portal/g/${spaceSiteKeyName}/home/agenda` : `/portal/${eXo.env.portal.siteKeyName}/home/agenda`;
       if (this.event.id) {
         eventDetailsPath = `${eventDetailsPath}?eventId=${this.event.id}`;
       } else if (this.event.parent && this.event.parent.id && this.event.occurrence && this.event.occurrence.id) {


### PR DESCRIPTION

Prior to this change, when refreshing the event detail url coming from agenda event timeline gadget, the last accessed page is displayed instead the agenda event detail drawer. This is due to the wrong url generated for the event detail url coming from agenda event timeline gadget which consists on the current page url concatenated with agenda event id. After this commit, we ensure to generate the right event detail url according to the site type (portal or space) in order to be used later to display the needed agenda event detail drawer.