### PR TITLE
fix: Can't create event with user invitation by email in uppercase letters - EXO-75566

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
@@ -162,7 +162,7 @@ export default {
     },
     saveGuestEmail() {
       const reg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,24}))$/;
-      const input = this.$refs.invitedAttendeeAutoComplete.searchTerm;
+      const input = this.$refs?.invitedAttendeeAutoComplete?.searchTerm?.toLowerCase();
       const words = input!== null ? input.split(' ') : '';
       const email = words[words.length - 1];
       if (reg.test(email)) {


### PR DESCRIPTION
Before this change, when open agenda application of a space and create an event or a poll and invite a user by typing his email with at least one char in uppercase, event isn't created. To fix this problem, change the email to lowercase. After this change, Event is created.