### PR TITLE
Fix: Last day of a custom recurring event isn't considered - EXO-80090

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormRecurrenceDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormRecurrenceDrawer.vue
@@ -189,7 +189,9 @@ export default {
         return;
       }
       if (this.recurrentEventDate === 'date') {
-        this.eventRecurrence.until = this.$agendaUtils.toRFC3339(this.untilDate);
+        const endDate = new Date(this.untilDate);
+        endDate.setHours(23, 59, 59, 999);
+        this.eventRecurrence.until = this.$agendaUtils.toRFC3339(endDate);
         this.eventRecurrence.count = '';
       } else if (this.recurrentEventDate === 'count') {
         this.eventRecurrence.until = null;


### PR DESCRIPTION
Before this change, when creating a recurrent event and checking the last recurrence of the event, the last created event recurrence is the day before the last. To fix this problem, force the time to 23:59:59 to include the entire day. After this change, the last recurrence of the event is displayed correctly.