### PR TITLE
fix: Fix the one-hour offset in Outlook Desktop importing eXo ics file - eXo-78656

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -649,6 +649,8 @@ public class Utils {
     calendar.getProperties().add(new ProdId("PRODID:-//"+ brandingService.getSiteName() + "//" + brandingService.getCompanyName() + "//EN"));
     calendar.getProperties().add(Version.VERSION_2_0);
     calendar.getProperties().add(CalScale.GREGORIAN);
+    // Explicitly add VTIMEZONE component
+    calendar.getComponents().add(ical4jTimezone.getVTimeZone());
 
     Identity eventOrganozerIdentity = identityManager.getIdentity(eventModifierId);
     if(eventOrganozerIdentity != null) {

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -3324,8 +3324,8 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
     assertEquals(1, messageInfo.getAttachment().size());
     String text = new String(messageInfo.getAttachment().get(0).getInputStream().readAllBytes(), StandardCharsets.UTF_8);
     List<String> lines = text.contains("\r\n") ? List.of(text.split("\r\n")) : List.of(text.split("\n"));
-    String dtStart = lines.stream().filter(s -> s.contains("DTSTART")).findAny().get();
-    String dtEnd = lines.stream().filter(s -> s.contains("DTEND")).findAny().get();
+    String dtStart = lines.stream().filter(s -> s.contains("DTSTART;TZID")).findAny().get();
+    String dtEnd = lines.stream().filter(s -> s.contains("DTEND;TZID")).findAny().get();
     assertNotNull(dtStart);
     assertNotNull(dtEnd);
     String icsStartDate = dtStart.substring(dtStart.indexOf(":") + 1);


### PR DESCRIPTION
Currently, the generated ics file is missing the VTIMEZONE which makes it prone to misinterpretation by clients like Outlook and would cause the one-hour offset. To fix such issue, Added calendar.getComponents().add(ical4jTimezone.getVTimeZone()) to explicitly include the VTIMEZONE component to avoid the misinterpretation.