### PR TITLE
fix: start date and end date of an event is the same - EXO-81820.

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -378,12 +378,16 @@ export default {
     eventMouseMove(params) {
       if (this.dragEvent) {
         if (this.eventExtended) {
-          const newDate = this.$agendaUtils.toDateTime(params, false);
-          if (newDate >= this.$agendaUtils.toDate(this.dragEvent.startDate).getTime()) {
-            this.dragEvent.endDate = this.$agendaUtils.toDateTime(params, true);
+          const newTimeMs = this.$agendaUtils.toDateTime(params, false);
+          const start = this.$agendaUtils.toDate(this.dragEvent.startDate).getTime();
+          const minEndTimeMs = start + this.$agendaUtils.MINIMUM_TIME_INTERVAL_MS;
+          let finalEndTimeMs;
+          if (newTimeMs > minEndTimeMs) {
+            finalEndTimeMs = this.$agendaUtils.toDateTime(params, true);
           } else {
-            this.dragEvent.endDate = this.dragEvent.startDate;
+            finalEndTimeMs = minEndTimeMs;
           }
+          this.dragEvent.endDate = new Date(finalEndTimeMs);
         } else {
           const newTime = this.$agendaUtils.toDateTime(params, false);
           if (!Number.isNaN(newTime)) {


### PR DESCRIPTION
Before this change, when open calendar app of spacex and create an event from 10am to 10.30 am then expand the time using the mouse then put it back to the first choosen date and open the event drawer, the start date and end date is the same 10am. To fix this problem, add 30 minutes to the start date if the end date is equal to or less than the start date. After this change, the time is the same, at least 30 minute between start and end date.