### PR TITLE
Fix: Remove an extra word from german label of add event in Agenda portlet - EXO-83613

### DIFF
--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_de.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_de.properties
@@ -47,7 +47,7 @@ agenda.label.after=Nach
 agenda.label.events=Events
 agenda.label.untilDate=Bis
 agenda.label.createdBy=Erstellt von {0}
-agenda.label.start.adding.events=Event hinzuf\u00fcgen\n
+agenda.label.start.adding.events=Event hinzuf\u00fcgen
 
 agenda.title.addEvent=Event hinzuf\u00fcgen
 agenda.confirmCancelRecurrentEventTitle=Event absagen?


### PR DESCRIPTION

Before change \n was added at the end of label agenda.label.start.adding.events in german langauge , and after change \n was removed.