### PR TITLE
fix: Cannot change view on expand mode of agenda app - EXO-84552

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -7,7 +7,9 @@
   .layout-drawer.agendaEventRemindersDrawer {
     z-index: 1060 !important;
   }
-  
+
+
+
   #exchangeSettingsDrawer, #caldavSettingsDrawer {
     z-index: 1065 !important;
   }
@@ -110,7 +112,9 @@
       }
     }
   }
-   
+  .agendaPeriodMenu {
+    z-index: 1100 !important;
+  }
   .agenda-application {
     .agenda-body {
       min-height: ~"calc(100vh - 200px)";

--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -8,8 +8,6 @@
     z-index: 1060 !important;
   }
 
-
-
   #exchangeSettingsDrawer, #caldavSettingsDrawer {
     z-index: 1065 !important;
   }


### PR DESCRIPTION
Before this fix when we add agenda as an app the switch menu is not working. This is due to that the z-index of the drawer is higher than the one of the switch menu, this commit fix this by increasing the z-index of the menu.