### PR TITLE
fix: Cannot select several day in month view - EXO-84598

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -134,8 +134,7 @@
           padding-left: 2px !important;
           .v-event {
             border: 1px solid !important;
-            max-width: 100%;
-            width: 100%!important;
+            min-width: 100%;
           }
         } 
         .v-event-timed-container{


### PR DESCRIPTION
Before this, it's not possible to select several days on the month view
This commit fix that by allowing events to have a width greater that the agenda interval width.