### PR TITLE
fix: Remove useless drawer event listeners

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -176,17 +176,10 @@ export default {
     this.$root.$on('agenda-event-change-owner', this.refreshProviders);
     this.$root.$on('agenda-show-remote-change', this.showRemoteEvents);
     this.spaceId = eXo.env.portal.spaceId;
-    document.addEventListener('drawerOpened', () => this.$el.closest('#stickyBlockDesktop').style.position = 'static');
-    document.addEventListener('drawerClosed', () => this.$el.closest('#stickyBlockDesktop').style.position = 'sticky');
     // Asynchronously load settings to use it in dialogs,
     // not needed for main screen display
     this.initSettings();
   },
-  beforeDestroy() {
-    document.removeEventListener('drawerOpened', () => this.$el.closest('#stickyBlockDesktop').style.position = 'static');
-    document.removeEventListener('drawerClosed', () => this.$el.closest('#stickyBlockDesktop').style.position = 'sticky');
-  },
-
   methods: {
     initSettings(userSettings) {
       if (userSettings) {


### PR DESCRIPTION
Before this change when opening any drawer while being in Dashboard page, a JS error is catched:
<img width="678" height="141" alt="image" src="https://github.com/user-attachments/assets/41b9a2f5-703c-4add-97e8-a2c3ac6cf0b3" />

This change will remove event listeners for drawerOpened and drawerClosed in beforeDestroy lifecycle hook knowing that the parent element doesn't exist anymore and the hook aren't relevant anymore due to the fact that drawers are mounted outside of parent app element.