### PR TITLE
fix: Filter all event not working - EXO-84609

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/filter/AgendaFilterCalendarDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/filter/AgendaFilterCalendarDrawer.vue
@@ -15,13 +15,13 @@
             v-model="eventType">
             <v-radio
               :label="$t('agenda.myEvent')"
-              value="myEvent" />
+              value="myEvents" />
             <v-radio
               :label="$t('agenda.declinedEvent')"
               value="declinedEvent" />
             <v-radio
-              :label="$t('agenda.allEvent')"
-              value="allEvent" />
+              :label="$t('agenda.allEvents')"
+              value="allEvents" />
           </v-radio-group>
         </div>
       </div>
@@ -120,7 +120,7 @@ export default {
       if (this.calendarType === 'month') {this.showWholeWeek = true;}
       this.lastShowWholeWeek = this.showWholeWeek;
       if (!this.eventType){
-        this.eventType = this.currentSpace ? 'allEvent' : 'myEvent';
+        this.eventType = this.currentSpace ? 'allEvents' : 'myEvents';
       }
       this.$refs.calendarFilters.open();
     },
@@ -131,7 +131,7 @@ export default {
       this.$refs.calendarFilters.close();
     },
     init() {
-      this.eventType = this.currentSpace ? 'allEvent' : 'myEvent';
+      this.eventType = this.currentSpace ? 'allEvents' : 'myEvents';
       this.showWholeWeek = this.defaultShowWholeWeek;
       this.confirm();
     },


### PR DESCRIPTION
Prior to this fix, when user filters the agenda to "All events" it do not display all the events. It's due to wrong filter value.