### PR TITLE
fix: Fix inconsistency in the week number between the display by month and the display by week - EXO-85200

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -12,6 +12,7 @@
     :interval-height="40"
     :event-overlap-threshold="30"
     :locale="lang"
+    :locale-first-day-of-year="4"
     event-overlap-mode="stack"
     event-name="summary"
     event-start="startDate"


### PR DESCRIPTION
Prior to this change, the week number in month view is wrongly displayed and not consistent compared to week view one.
This is due to the v-calendar vue component using the US default rule (Week 1 contains Jan 1st), causing a one-week offset in 2026 compared to the ISO 8601 standard. After this commit, we have added :locale-first-day-of-year="4" to force the "First Thursday" rule, ensuring the week numbers align with our internal logic and European standards.