### PR TITLE
fix: Can't accept an invitation - EXO-85798

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventService.js
@@ -169,6 +169,20 @@ export function updateEvent(event) {
     });
 }
 
+export function sendEventResponse(eventId, occurrenceId, response, upcoming) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/agenda/events/${eventId}/response/send?response=${response}&occurrenceId=${occurrenceId || ''}&upcoming=${upcoming || false}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  }).then((resp) => {
+    if (!resp || !resp.ok) {
+      throw new Error('Error sending event response');
+    }
+  });
+}
+
 export function updateEventFields(event, eventFields, updateAllOccurrences, sendInvitations) {
   const eventId = event.id;
   eventFields = formatEventToSave(eventFields);


### PR DESCRIPTION
Before this change, when create event and invite userX to an event userX connects and accept/refuses event invitation, choice never saved and displays infinite loading + errors are displayed browser console. To fix this issue, add sendEventResponse method. after this change, choice is saved.