### PR TITLE
fix: Fix add/edit agenda event XSS vulnerability - EXO-84910

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/RestEntityBuilder.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/RestEntityBuilder.java
@@ -27,6 +27,7 @@ import org.exoplatform.agenda.model.*;
 import org.exoplatform.agenda.rest.model.*;
 import org.exoplatform.agenda.service.AgendaCalendarService;
 import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.rest.entity.IdentityEntity;
@@ -119,7 +120,7 @@ public class RestEntityBuilder {
                      AgendaDateUtils.parseRFC3339ToZonedDateTime(eventEntity.getCreated(), ZoneOffset.UTC),
                      AgendaDateUtils.parseRFC3339ToZonedDateTime(eventEntity.getUpdated(), ZoneOffset.UTC),
                      eventEntity.getSummary(),
-                     eventEntity.getDescription(),
+                     HTMLSanitizer.sanitize(eventEntity.getDescription()),
                      eventEntity.getLocation(),
                      eventEntity.getColor(),
                      eventZoneId,


### PR DESCRIPTION
Prior to this change, when creating or editing an agenda event, a JavaScript payload inserted in the description field could be executed when the event was edited, leading to an XSS vulnerability.
With this commit, the description value is sanitized using HTMLSanitizer.sanitize before being stored in the database, preventing the XSS vulnerability.