### PR TITLE
fix: handle delete news event in ContentUpdateListener and adding event/content update sync listeners - EXO-86412 - exoplatform/eXIP#41

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/content/AgendaEventContentSyncListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/content/AgendaEventContentSyncListener.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.listener.content;
+
+import io.meeds.content.news.model.News;
+import io.meeds.content.news.service.NewsService;
+import io.meeds.content.news.utils.NewsUtils;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.exoplatform.agenda.model.AgendaEventModification;
+import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataObject;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.exoplatform.agenda.util.Utils.*;
+
+@Asynchronous
+@Component
+@RequiredArgsConstructor
+public class AgendaEventContentSyncListener extends Listener<AgendaEventModification, Object> {
+
+  private final ListenerService listenerService;
+
+  private final AgendaEventService agendaEventService;
+
+  private final MetadataService metadataService;
+
+  private final NewsService newsService;
+
+  private final IdentityManager identityManager;
+
+  @PostConstruct
+  public void init() {
+    listenerService.addListener(POST_UPDATE_AGENDA_EVENT_EVENT, this);
+  }
+
+  @Override
+  public void onEvent(Event<AgendaEventModification, Object> event) throws Exception {
+    AgendaEventModification agendaEventModification = event.getSource();
+    long eventId = agendaEventModification.getEventId();
+
+    MetadataObject metadataObject = new MetadataObject(EVENT_METADATA_NAME, String.valueOf(eventId));
+    List<MetadataItem> metadataItems =
+        metadataService.getMetadataItemsByMetadataAndObject(EVENT_METADATA_KEY, metadataObject);
+    if (CollectionUtils.isEmpty(metadataItems)) {
+      return;
+    }
+
+    Map<String, String> properties = metadataItems.getFirst().getProperties();
+    if (!properties.containsKey(CONTENT_ID)) {
+      return;
+    }
+
+    String contentId = properties.get(CONTENT_ID);
+    News news = newsService.getNewsArticleById(contentId);
+    if (news == null) {
+      return;
+    }
+
+    org.exoplatform.agenda.model.Event agendaEvent = agendaEventService.getEventById(eventId);
+    if (agendaEvent == null) {
+      return;
+    }
+
+    if (!agendaEvent.getSummary().equals(news.getTitle())) {
+      news.setTitle(agendaEvent.getSummary());
+      String updater = identityManager.getIdentity(agendaEventModification.getModifierId()).getRemoteId();
+      newsService.updateNews(news,
+                             updater,
+                             false,
+                             false,
+                             "article",
+                             NewsUtils.NewsUpdateType.CONTENT_AND_TITLE.name());
+    }
+  }
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/content/ContentAgendaEventSyncListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/content/ContentAgendaEventSyncListener.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.listener.content;
+
+import io.meeds.content.news.model.News;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.meeds.content.news.utils.NewsUtils.UPDATE_NEWS;
+import static org.exoplatform.agenda.util.Utils.EVENT_ID;
+
+@Asynchronous
+@Component
+@RequiredArgsConstructor
+public class ContentAgendaEventSyncListener extends Listener<String, News> {
+
+  private final ListenerService listenerService;
+
+  private final AgendaEventService agendaEventService;
+
+  private final IdentityManager identityManager;
+
+  @PostConstruct
+  public void init() {
+    listenerService.addListener(UPDATE_NEWS, this);
+  }
+
+  @Override
+  public void onEvent(Event<String, News> event) throws Exception {
+    News news = event.getData();
+    Map<String, String> parameters = news.getParameters();
+    if (parameters == null || !parameters.containsKey(EVENT_ID)) {
+      return;
+    }
+
+    long eventId = Long.parseLong(parameters.get(EVENT_ID));
+    org.exoplatform.agenda.model.Event agendaEvent = agendaEventService.getEventById(eventId);
+    if (agendaEvent == null) {
+      return;
+    }
+
+    if (agendaEvent.getSummary().equals(news.getTitle())) {
+      return;
+    }
+
+    String authorRemoteId = news.getAuthor();
+    long modifierId = identityManager.getOrCreateUserIdentity(authorRemoteId).getIdentityId();
+
+    agendaEventService.updateEventFields(agendaEvent.getId(),
+                                         Map.of("summary", List.of(news.getTitle())),
+                                         false,
+                                         false,
+                                         modifierId);
+  }
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/content/ContentUpdateListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/content/ContentUpdateListener.java
@@ -28,14 +28,13 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
 
-import static io.meeds.content.news.utils.NewsUtils.UPDATE_NEWS;
 import static io.meeds.content.news.utils.NewsUtils.DELETE_NEWS;
+import static io.meeds.content.news.utils.NewsUtils.UPDATE_NEWS;
 import static org.exoplatform.agenda.util.Utils.*;
 
 @Asynchronous
@@ -60,32 +59,69 @@ public class ContentUpdateListener extends Listener<String, News> {
 
   @Override
   public void onEvent(Event<String, News> event) throws Exception {
+    String eventName = event.getEventName();
+    if (!eventName.equalsIgnoreCase(UPDATE_NEWS) && !eventName.equalsIgnoreCase(DELETE_NEWS)) {
+      return;
+    }
+
     News news = event.getData();
-    if (event.getEventName().equalsIgnoreCase(UPDATE_NEWS)) {
-      Map<String, String> parameters = news.getParameters();
-      if (parameters == null || !parameters.containsKey(EVENT_ID)) {
+    Map<String, String> parameters = news.getParameters();
+    if (parameters == null || !parameters.containsKey(EVENT_ID)) {
+      return;
+    }
+
+    long eventId = Long.parseLong(parameters.get(EVENT_ID));
+    MetadataObject metadataObject = new MetadataObject(EVENT_METADATA_NAME, String.valueOf(eventId));
+
+    if (eventName.equalsIgnoreCase(DELETE_NEWS)) {
+      List<MetadataItem> metadataItems =
+          metadataService.getMetadataItemsByMetadataAndObject(EVENT_METADATA_KEY, metadataObject);
+      handleDeleteNews(news, metadataItems);
+    } else {
+      org.exoplatform.agenda.model.Event agendaEvent = agendaEventService.getEventById(eventId);
+      if (agendaEvent == null) {
         return;
       }
-      long eventId = Long.parseLong(parameters.get(EVENT_ID));
-      org.exoplatform.agenda.model.Event agendaEvent = agendaEventService.getEventById(eventId);
-      if (agendaEvent != null) {
-        MetadataObject metadataObject = new MetadataObject(EVENT_METADATA_NAME, String.valueOf(eventId));
-        Map<String, String> properties = Map.of(CONTENT_ID, String.valueOf(news.getId()));
-        List<MetadataItem> metadataItems =
-            metadataService.getMetadataItemsByMetadataAndObject(EVENT_METADATA_KEY, metadataObject);
-        if (CollectionUtils.isEmpty(metadataItems)) {
-          metadataService.createMetadataItem(metadataObject, EVENT_METADATA_KEY, properties, agendaEvent.getCreatorId());
-        } else {
-          MetadataItem metadataItem = metadataItems.getFirst();
-          Map<String, String> existingProperties = metadataItem.getProperties();
-          if (!existingProperties.containsKey(CONTENT_ID)
-              || !existingProperties.get(CONTENT_ID).equals(String.valueOf(news.getId()))) {
-            existingProperties.putAll(properties);
-            metadataItem.setProperties(existingProperties);
-            metadataService.updateMetadataItem(metadataItem, agendaEvent.getModifierId());
-          }
-        }
+      List<MetadataItem> metadataItems =
+          metadataService.getMetadataItemsByMetadataAndObject(EVENT_METADATA_KEY, metadataObject);
+      handleUpdateNews(news, agendaEvent, metadataObject, metadataItems);
+    }
+  }
+
+  private void handleUpdateNews(News news,
+                                org.exoplatform.agenda.model.Event agendaEvent,
+                                MetadataObject metadataObject,
+                                List<MetadataItem> metadataItems) throws Exception {
+    Map<String, String> properties = Map.of(CONTENT_ID, String.valueOf(news.getId()));
+    if (CollectionUtils.isEmpty(metadataItems)) {
+      metadataService.createMetadataItem(metadataObject, EVENT_METADATA_KEY, properties, agendaEvent.getCreatorId());
+    } else {
+      MetadataItem metadataItem = metadataItems.getFirst();
+      Map<String, String> existingProperties = metadataItem.getProperties();
+      if (!existingProperties.containsKey(CONTENT_ID)
+          || !existingProperties.get(CONTENT_ID).equals(String.valueOf(news.getId()))) {
+        existingProperties.putAll(properties);
+        metadataItem.setProperties(existingProperties);
+        metadataService.updateMetadataItem(metadataItem, getModifierOrCreatorId(agendaEvent));
       }
     }
+  }
+
+  private void handleDeleteNews(News news, List<MetadataItem> metadataItems) throws Exception {
+    if (CollectionUtils.isEmpty(metadataItems)) {
+      return;
+    }
+    MetadataItem metadataItem = metadataItems.getFirst();
+    Map<String, String> existingProperties = metadataItem.getProperties();
+    if (existingProperties.containsKey(CONTENT_ID)
+        && existingProperties.get(CONTENT_ID).equals(String.valueOf(news.getId()))) {
+      existingProperties.remove(CONTENT_ID);
+      metadataItem.setProperties(existingProperties);
+      metadataService.updateMetadataItem(metadataItem, metadataItem.getCreatorId());
+    }
+  }
+
+  private long getModifierOrCreatorId(org.exoplatform.agenda.model.Event agendaEvent) {
+    return agendaEvent.getModifierId() != 0 ? agendaEvent.getModifierId() : agendaEvent.getCreatorId();
   }
 }

--- a/agenda-services/src/test/java/org/exoplatform/agenda/listener/content/ContentUpdateListenerTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/listener/content/ContentUpdateListenerTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, see<http://www.gnu.org/licenses/>.
  */
+
 package org.exoplatform.agenda.listener.content;
 
 import io.meeds.content.news.model.News;
@@ -29,9 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.meeds.content.news.utils.NewsUtils.*;
 import static org.exoplatform.agenda.util.Utils.EVENT_METADATA_KEY;
@@ -61,9 +60,11 @@ public class ContentUpdateListenerTest {
   @BeforeEach
   public void setUp() {
     news = new News();
+
     Map<String, String> params = new HashMap<>();
     params.put("eventId", "123");
     news.setParameters(params);
+
     news.setId("999");
   }
 
@@ -77,121 +78,163 @@ public class ContentUpdateListenerTest {
   }
 
   @Test
-  public void shouldCreateMetadataWhenUpdateNewsWithValidEventId() throws Exception {
+  public void shouldCreateMetadataWhenNoExistingItem() throws Exception {
     when(event.getEventName()).thenReturn(UPDATE_NEWS);
     when(event.getData()).thenReturn(news);
 
-    org.exoplatform.agenda.model.Event agendaEvent = mock(org.exoplatform.agenda.model.Event.class);
+    org.exoplatform.agenda.model.Event agendaEvent =
+        mock(org.exoplatform.agenda.model.Event.class);
+
     when(agendaEvent.getCreatorId()).thenReturn(1L);
     when(agendaEventService.getEventById(123L)).thenReturn(agendaEvent);
-    when(metadataService.getMetadataItemsByMetadataAndObject(any(), any())).thenReturn(new java.util.ArrayList<>());
+
+    when(metadataService.getMetadataItemsByMetadataAndObject(any(), any()))
+        .thenReturn(Collections.emptyList());
 
     contentUpdateListener.onEvent(event);
 
-    ArgumentCaptor<MetadataObject> metadataCaptor = ArgumentCaptor.forClass(MetadataObject.class);
-    ArgumentCaptor<Map<String, String>> propsCaptor = ArgumentCaptor.forClass(Map.class);
-
     verify(metadataService).createMetadataItem(
-        metadataCaptor.capture(),
+        any(MetadataObject.class),
         eq(EVENT_METADATA_KEY),
-        propsCaptor.capture(),
+        anyMap(),
         eq(1L)
     );
 
-    MetadataObject metadata = metadataCaptor.getValue();
-    Map<String, String> props = propsCaptor.getValue();
-    assertEquals("agendaEvent", metadata.getType());
-    assertEquals("123", metadata.getId());
-    assertEquals("999", props.get("contentId"));
+    verify(metadataService, never()).updateMetadataItem(any(), anyLong());
   }
 
   @Test
-  public void shouldUpdateMetadataWhenContentIdChanged() throws Exception {
+  public void shouldUpdateMetadataWhenContentChanged() throws Exception {
     when(event.getEventName()).thenReturn(UPDATE_NEWS);
     when(event.getData()).thenReturn(news);
 
-    org.exoplatform.agenda.model.Event agendaEvent = mock(org.exoplatform.agenda.model.Event.class);
-    when(agendaEvent.getModifierId()).thenReturn(1L);
+    org.exoplatform.agenda.model.Event agendaEvent =
+        mock(org.exoplatform.agenda.model.Event.class);
+
+    when(agendaEvent.getModifierId()).thenReturn(2L);
     when(agendaEventService.getEventById(123L)).thenReturn(agendaEvent);
 
-    MetadataItem existingItem = mock(MetadataItem.class);
-    Map<String, String> existingProps = new HashMap<>();
-    existingProps.put("contentId", "000"); // different from news.getId() "999"
-    when(existingItem.getProperties()).thenReturn(existingProps);
+    MetadataItem item = mock(MetadataItem.class);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("contentId", "000");
+
+    when(item.getProperties()).thenReturn(props);
+
     when(metadataService.getMetadataItemsByMetadataAndObject(any(), any()))
-        .thenReturn(List.of(existingItem));
+        .thenReturn(List.of(item));
 
     contentUpdateListener.onEvent(event);
 
-    verify(metadataService).updateMetadataItem(eq(existingItem), eq(1L));
+    verify(metadataService).updateMetadataItem(eq(item), eq(2L));
     verify(metadataService, never()).createMetadataItem(any(), any(), any(), anyLong());
   }
 
   @Test
-  public void shouldNotUpdateMetadataWhenContentIdUnchanged() throws Exception {
+  public void shouldNotUpdateWhenContentUnchanged() throws Exception {
     when(event.getEventName()).thenReturn(UPDATE_NEWS);
     when(event.getData()).thenReturn(news);
 
-    org.exoplatform.agenda.model.Event agendaEvent = mock(org.exoplatform.agenda.model.Event.class);
+    org.exoplatform.agenda.model.Event agendaEvent =
+        mock(org.exoplatform.agenda.model.Event.class);
+
     when(agendaEventService.getEventById(123L)).thenReturn(agendaEvent);
 
-    MetadataItem existingItem = mock(MetadataItem.class);
-    Map<String, String> existingProps = new HashMap<>();
-    existingProps.put("contentId", "999"); // same as news.getId()
-    when(existingItem.getProperties()).thenReturn(existingProps);
+    MetadataItem item = mock(MetadataItem.class);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("contentId", "999");
+
+    when(item.getProperties()).thenReturn(props);
+
     when(metadataService.getMetadataItemsByMetadataAndObject(any(), any()))
-        .thenReturn(List.of(existingItem));
+        .thenReturn(List.of(item));
 
     contentUpdateListener.onEvent(event);
 
     verify(metadataService, never()).updateMetadataItem(any(), anyLong());
     verify(metadataService, never()).createMetadataItem(any(), any(), any(), anyLong());
+  }
+
+  @Test
+  public void shouldRemoveContentIdOnDelete() throws Exception {
+    when(event.getEventName()).thenReturn(DELETE_NEWS);
+    when(event.getData()).thenReturn(news);
+
+    MetadataItem item = mock(MetadataItem.class);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("contentId", "999");
+
+    when(item.getProperties()).thenReturn(props);
+
+    when(metadataService.getMetadataItemsByMetadataAndObject(any(), any()))
+        .thenReturn(List.of(item));
+
+    contentUpdateListener.onEvent(event);
+
+    assertFalse(item.getProperties().containsKey("contentId"));
+
+    verify(metadataService).updateMetadataItem(eq(item), anyLong());
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoMetadataOnDelete() throws Exception {
+    when(event.getEventName()).thenReturn(DELETE_NEWS);
+    when(event.getData()).thenReturn(news);
+
+    when(metadataService.getMetadataItemsByMetadataAndObject(any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    contentUpdateListener.onEvent(event);
+
+    verify(metadataService, never()).updateMetadataItem(any(), anyLong());
+    verify(metadataService, never()).createMetadataItem(any(), any(), any(), anyLong());
+  }
+
+  @Test
+  public void shouldIgnoreUnrelatedEvents() throws Exception {
+    when(event.getEventName()).thenReturn("OTHER_EVENT");
+
+    contentUpdateListener.onEvent(event);
+
+    verifyNoInteractions(metadataService);
+    verifyNoInteractions(agendaEventService);
   }
 
   @Test
   public void shouldNotProcessWhenParametersNull() throws Exception {
     news.setParameters(null);
+
     when(event.getEventName()).thenReturn(UPDATE_NEWS);
     when(event.getData()).thenReturn(news);
 
     contentUpdateListener.onEvent(event);
 
-    verify(metadataService, never()).createMetadataItem(any(), any(), any(), anyLong());
-    verify(metadataService, never()).updateMetadataItem(any(), anyLong());
+    verifyNoInteractions(metadataService);
   }
 
   @Test
   public void shouldNotProcessWhenEventIdMissing() throws Exception {
     news.setParameters(new HashMap<>());
+
     when(event.getEventName()).thenReturn(UPDATE_NEWS);
     when(event.getData()).thenReturn(news);
 
     contentUpdateListener.onEvent(event);
 
-    verify(metadataService, never()).createMetadataItem(any(), any(), any(), anyLong());
-    verify(metadataService, never()).updateMetadataItem(any(), anyLong());
+    verifyNoInteractions(metadataService);
   }
 
   @Test
   public void shouldNotProcessWhenAgendaEventNotFound() throws Exception {
     when(event.getEventName()).thenReturn(UPDATE_NEWS);
     when(event.getData()).thenReturn(news);
+
     when(agendaEventService.getEventById(123L)).thenReturn(null);
 
     contentUpdateListener.onEvent(event);
 
-    verify(metadataService, never()).createMetadataItem(any(), any(), any(), anyLong());
-    verify(metadataService, never()).updateMetadataItem(any(), anyLong());
-  }
-
-  @Test
-  public void shouldIgnoreUnrelatedEvents() throws Exception {
-    when(event.getEventName()).thenReturn("someOtherEvent");
-    when(event.getData()).thenReturn(news);
-
-    contentUpdateListener.onEvent(event);
-
     verifyNoInteractions(metadataService);
-    verifyNoInteractions(agendaEventService);
   }
 }


### PR DESCRIPTION
Remove contentId from event metadata properties when associated news is deleted.
Add handleDeleteNews method to remove contentId from metadata item properties
Add sync listeners to sync update of title between event/content