### PR TITLE
fix: Avoid NPE when User Profile is Null

### DIFF
--- a/agenda-webapps/src/main/webapp/groovy/UIPortalAgendaHead.gtmpl
+++ b/agenda-webapps/src/main/webapp/groovy/UIPortalAgendaHead.gtmpl
@@ -2,10 +2,12 @@
   import org.exoplatform.container.ExoContainerContext;
   import org.exoplatform.services.security.ConversationState;
   import org.exoplatform.services.organization.OrganizationService;
+  import org.exoplatform.services.organization.UserProfile;
 
   OrganizationService organizationService = ExoContainerContext.getService(OrganizationService.class);
   String userName = ConversationState.getCurrent().getIdentity().getUserId();
-  String userTimezone = organizationService.getUserProfileHandler().findUserProfileByName(userName).getAttribute("user.timeZone");
+  UserProfile userProfile = organizationService.getUserProfileHandler().findUserProfileByName(userName);
+  String userTimezone = userProfile == null ? null : userProfile.getAttribute("user.timeZone");
 
 %><script type="text/javascript">
   eXo.env.portal.userTimezone=<%= userTimezone == null ? "null" : "'%s'".formatted(userTimezone) %>;


### PR DESCRIPTION
Prior to this change, when the UserProfile Entity isn't stored in database yet, then the display of UIPortalAgendaHead.gtmpl throws an NPE exception. This change avoid NPE by making a test on UserProfile existence before accessing the User TimeZone Attribute.