### PR TITLE
feat: Add ContentType Definition in Search Connector - EXO-86376

### DIFF
--- a/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/search-configuration.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/conf/agenda/search-configuration.xml
@@ -54,6 +54,9 @@
             <field name="name">
               <string>events</string>
             </field>
+            <field name="contentType">
+              <string>agendaEvent</string>
+            </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/v1/agenda/events/search?limit={limit}&query={keyword}&expand=response]]></string>
             </field>


### PR DESCRIPTION
This change will allow to define the associated 'contentType' for each Search Connector to allow automatic filtering on content types.