### PR TITLE
fix: period selector has a null end date - EXO-85744

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
@@ -408,7 +408,7 @@ export default {
       }
     },
     retrieveRemoteEvents() {
-      if (this.connectorStatus === 1) {
+      if (this.settingsLoaded && this.connectorStatus === 1) {
         const startDateRFC3359 = this.$agendaUtils.toRFC3339(this.period.start, false, true);
         const endDateRFC3359 = this.$agendaUtils.toRFC3339(this.period.end, false, true);
         this.loading = true;

--- a/agenda-webapps/webpack.watch.js
+++ b/agenda-webapps/webpack.watch.js
@@ -5,8 +5,10 @@ const webpackProductionConfig = require('./webpack.prod.js');
 
 module.exports = merge(webpackProductionConfig, {
   mode: 'development',
+  devtool: 'eval-source-map',
   output: {
     path: '/exo-server/webapps/agenda/',
-    filename: 'js/[name].bundle.js'
+    filename: 'js/[name].bundle.js',
+    libraryTarget: 'amd'
   }
 });


### PR DESCRIPTION
When loading agenda application, the displayed period is refreshed while it is still initializing and does not have an end date. This causes error while retrieving events from external connectors.
the fix waits that the agenda is fully loaded before querying the agenda external connectors 