### PR TITLE
fix: display remote single and repetitive events in date polls - EXO-86362

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDates.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormDates.vue
@@ -215,7 +215,7 @@ export default {
       // Avoid to have same event from remote and local store (pushed events from local store)
       if (this.spaceEvents.length && remoteEventsToDisplay.length) {
         this.spaceEvents.forEach(event => {
-          const index = remoteEventsToDisplay.findIndex(remoteEvent => remoteEvent.id && remoteEvent.id === event.remoteId || remoteEvent.recurringEventId && remoteEvent.recurringEventId === event.remoteId);
+          const index = remoteEventsToDisplay.findIndex(remoteEvent => remoteEvent.id && remoteEvent.id === event.remoteId || (remoteEvent.recurringEventId && remoteEvent.recurringEventId === event.parent?.remoteId));
           if (index >= 0) {
             remoteEventsToDisplay.splice(index, 1);
           }

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
@@ -62,7 +62,6 @@ function createConference(event, conference) {
       const spaces = identities.filter(identity => identity && identity.providerId === 'space').map(identity => identity.remoteId);
       const startDate = new Date(event.start);
       const endDate = event.endDate && new Date(event.end) || event.recurrence && event.recurrence.until && new Date(event.recurrence.until) || null;
-      console.log('Creating conference with recurrence ' , event.recurrence);
       return global.webConferencing.addCall({
         title: event.title,
         owner: event.calendar.owner.id,

--- a/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
@@ -408,7 +408,7 @@ export default {
       }
     },
     retrieveRemoteEvents() {
-      if (this.connectorStatus === 1) {
+      if (this.settingsLoaded && this.connectorStatus === 1) {
         const startDateRFC3359 = this.$agendaUtils.toRFC3339(this.period.start, false, true);
         const endDateRFC3359 = this.$agendaUtils.toRFC3339(this.period.end, false, true);
         this.loading = true;

--- a/agenda-webapps/webpack.watch.js
+++ b/agenda-webapps/webpack.watch.js
@@ -5,8 +5,10 @@ const webpackProductionConfig = require('./webpack.prod.js');
 
 module.exports = merge(webpackProductionConfig, {
   mode: 'development',
+  devtool: 'eval-source-map',
   output: {
     path: '/exo-server/webapps/agenda/',
-    filename: 'js/[name].bundle.js'
+    filename: 'js/[name].bundle.js',
+    libraryTarget: 'amd'
   }
 });


### PR DESCRIPTION
When loading agenda application, the displayed period is refreshed while it is still initializing and does not have an end date. This causes error while retrieving events from external connectors.
the fix waits that the agenda is fully loaded before querying the agenda external connectors.
Besides, it includes a fix for displaying recurring events created from the agenda app.
