### PR TITLE
fix:  Default value for see more in agenda timeline - EXO-87079

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
@@ -292,6 +292,13 @@ export default {
           this.timelineSettings.agendaSource =   'allUsersSpaces';
         }     
       }
+      if (this.timelineSettings.seeMoreUrl === '') {
+        if (eXo.env.portal.spaceId) {    
+          this.timelineSettings.seeMoreUrl = `${eXo.env.portal.context}/s/${eXo.env.portal.spaceId}/agenda`;
+        } else {
+          this.timelineSettings.seeMoreUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;
+        }
+      }
       if (this.timelineSettings.displayPending !== false) {
         this.timelineSettings.displayPending = true;
       }


### PR DESCRIPTION
Prior to this fix, when adding the agenda timeline there is no default value for the see more option. This commit activate the see more option by default.