### PR TITLE
fix:  I can create an event even if I'm not member of a space sources - EXO-86734

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
@@ -26,7 +26,6 @@
       :title="addEventButtonTooltip"
       class="d-flex align-center">
       <v-btn
-        :disabled="!canCreateEvent"
         :title="$t('agenda.button.addEvent')"
         icon
         class="ms-auto"
@@ -111,7 +110,7 @@ export default {
       return this.$root.timelineSettings.customHeader && this.$root.headerTitle!=='null' ? this.$root.headerTitle : this.$t('agenda');
     },
     displayButton() {
-      return this.$root.timelineSettings.displayAddEvent !== false  &&  (!this.$root.isMobile || this.canCreateEvent) && (this.initialized || !eXo.env.portal.spaceId);
+      return (this.initialized || !eXo.env.portal.spaceId) && !this.$root.isMobile && this.canCreateEvent &&  this.$root.timelineSettings.displayAddEvent !== false;
     },
     displaySeeMore() {
       return this.$root.timelineSettings.displaySeeMore !== false ;


### PR DESCRIPTION
Prior to this fix, any user can add events even if he is not member of the selected spaces as agenda source. This commit allow only source spaces members to add events.