### PR TITLE
fix:  Display event of other month for few millisecond - EXO-86447

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -212,11 +212,13 @@ export default {
     });
     this.$root.$on('agenda-display-calendar-next', () => {
       if (this.$refs.calendar) {
+        this.events = [];
         this.$refs.calendar.next();
       }
     });
     this.$root.$on('agenda-display-calendar-previous', () => {
       if (this.$refs.calendar) {
+        this.events = [];
         this.$refs.calendar.prev();
       }
     });


### PR DESCRIPTION
Prior to this fix,when period is changed on month view, the event of the next or previous month are displayed for few milliseconds. This commit fix this by restting the list of events on period change.