### PR TITLE
fix:  Default value for see more in agenda timeline - EXO-87079

### DIFF
--- a/agenda-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -50,9 +50,12 @@
                    "selectedSpaces":[],
                    "agendaSource":"",
                    "customHeader":false,
-                   "displaySeeMore":false,
+                   "displaySeeMore":true,
                    "seeMoreUrl":"",
                    "displayPending":true,
+                   "displayAddEvent": true,
+                   "agendaFilter": 'allEvents',
+                   "itemsNumber": 10
                    }
                </value>
            </preference>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
@@ -113,7 +113,7 @@ export default {
       return (this.initialized || !eXo.env.portal.spaceId) && !this.$root.isMobile && this.canCreateEvent &&  this.$root.timelineSettings.displayAddEvent !== false;
     },
     displaySeeMore() {
-      return this.$root.timelineSettings.displaySeeMore && this.$root.timelineSettings.seeMoreUrl;
+      return this.$root.timelineSettings.displaySeeMore !== false ;
     },
     displayPendingEvents() {
       return this.$root.timelineSettings.displayPending;
@@ -150,11 +150,17 @@ export default {
       this.$root.$emit('agenda-connectors-drawer-open');
     },
     openSeeMoreLink () {
-      const url = this.$root.timelineSettings.seeMoreUrl;
-      if (url) {
-        window.open(url, '_blank');
+      let url = this.$root.timelineSettings.seeMoreUrl;
+      if (!url) {
+        if (eXo.env.portal.spaceId) {    
+          url = `${eXo.env.portal.context}/s/${eXo.env.portal.spaceId}/agenda`;
+        } else {
+          url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;
+        }
       }
-    },
+      window.open(url, '_blank');
+
+    }, 
   },
 };
 </script>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
@@ -193,17 +193,34 @@ export default {
     transUpdated: false,
     currentTranslations: [],
     timelineSettings: {
-      agendaSource: 'allUsersSpaces',
       selectedSpaces: [],
+      agendaSource: 'allUsersSpaces',
       customHeader: false,
+      displaySeeMore: true,
+      seeMoreUrl: '',
+      displayPending: true,
+      displayAddEvent: true,
+      agendaFilter: 'allEvents',
+      itemsNumber: 10
+    },
+    defaultTimelineSettings: {
+      selectedSpaces: [],
+      agendaSource: 'allUsersSpaces',
+      customHeader: false,
+      displaySeeMore: true,
+      seeMoreUrl: '',
+      displayPending: true,
+      displayAddEvent: true,
+      agendaFilter: 'allEvents',
+      itemsNumber: 10
     },
   }),
   computed: {
     disabled() {
-      return (this.timelineSettings.displaySeeMore && !this.isValidLink) || !this.modified;
+      return (this.timelineSettings.displaySeeMore && this.timelineSettings.seeMoreUrl !=='' && !this.isValidLink && (this.timelineSettings.agendaSource === 'selectedSpaces' ? this.timelineSettings.selectedSpaces.length > 0 : true) )  || !this.modified;
     },
     modified() {
-      return JSON.stringify(this.timelineSettings) !== JSON.stringify(this.$root.timelineSettings) && (this.timelineSettings.agendaSource === 'selectedSpaces' ? this.timelineSettings.selectedSpaces.length > 0 : true) || this.transUpdated;
+      return JSON.stringify(this.timelineSettings) !== JSON.stringify(this.defaultTimelineSettings) || this.transUpdated;
     },
     showSuggester() {
       return this.timelineSettings.agendaSource === 'selectedSpaces';
@@ -268,6 +285,7 @@ export default {
                   },
                 };
                 this.timelineSettings.selectedSpaces = [space];
+                this.defaultTimelineSettings.selectedSpaces = [space];
               }
             });
         }  else {
@@ -283,6 +301,10 @@ export default {
       if (!this.timelineSettings.itemsNumber) {
         this.timelineSettings.itemsNumber = 10;
       }
+      if (!this.timelineSettings.agendaFilter) {
+        this.timelineSettings.agendaFilter = 'allEvents';
+      }
+      this.defaultTimelineSettings = JSON.parse(JSON.stringify(this.timelineSettings));
       this.$refs.drawer.open();
     },
     close() {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
@@ -292,6 +292,13 @@ export default {
           this.timelineSettings.agendaSource =   'allUsersSpaces';
         }     
       }
+      if (this.timelineSettings.seeMoreUrl === '') {
+        if (eXo.env.portal.spaceId) {    
+          this.timelineSettings.seeMoreUrl = `${eXo.env.portal.context}/s/${eXo.env.portal.spaceId}/agenda`;
+        } else {
+          this.timelineSettings.seeMoreUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;
+        }
+      }
       if (this.timelineSettings.displayPending !== false) {
         this.timelineSettings.displayPending = true;
       }


### PR DESCRIPTION
Prior to this fix, when adding the agenda timeline, there was no default value for the see more option.
This commit activates the see more option by default.