### PR TITLE
fix: Agenda timeline see more option must open in the same tab - EXO-87271

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
@@ -163,8 +163,11 @@ export default {
           url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;
         }
       }
-      window.open(url, '_blank');
-
+      if (url.startsWith(eXo.env.portal.context)) {
+        window.open(url, '_self');
+      } else {
+        window.open(url, '_blank');
+      }
     }, 
   },
 };


### PR DESCRIPTION
Prior to this fix, the See more option always opens in a new tab. This commit changes this by setting the target depending on the URL.