### PR TITLE
fix: Agenda timeline - Title ellipsis - EXO-87084

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/top-toolbar/AgendaPeriodSelector.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/top-toolbar/AgendaPeriodSelector.vue
@@ -35,7 +35,7 @@
         fa-chevron-right
       </v-icon>
     </v-btn>
-    <div class="period-title text-uppercase my-auto ms-2">
+    <div class="period-title text-uppercase my-auto ms-2 text-no-wrap">
       {{ periodTitle }}
     </div>
   </div>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
@@ -1,73 +1,74 @@
 <template>
   <div class="agenda-timeline-header d-flex align-center justify-space-between px-5 pt-5">
-    <div class="d-flex align-center">
-      <div class="widget-text-header my-auto me-auto">
+    <div class="d-flex col-8">
+      <div class="widget-text-header text-truncate">
         {{ headerTitle }}
       </div>
       <agenda-period-selector
         v-if="!$root.isTimelineView"
         :period-title="periodTitle" />  
     </div>
-    <v-spacer />   
-    <agenda-pending-invitation-badge
-      v-if="displayPendingEvents"
-      :current-space="currentSpace"
-      :offset-y="18"
-      :offset-x="12" />
-    <agenda-connect-to-remote-button
-      width="28"
-      height="28"
-      size="20"
-      :connectors="connectors"
-      :settings="settings"
-      :show-default-remote-events="showDefaultRemoteEvents" /> 
-    <div
-      v-if="displayButton"
-      :title="addEventButtonTooltip"
-      class="d-flex align-center">
+    <div class="d-flex justify-end col-4">
+      <agenda-pending-invitation-badge
+        v-if="displayPendingEvents"
+        :current-space="currentSpace"
+        :offset-y="18"
+        :offset-x="12" />
+      <agenda-connect-to-remote-button
+        width="28"
+        height="28"
+        size="20"
+        :connectors="connectors"
+        :settings="settings"
+        :show-default-remote-events="showDefaultRemoteEvents" /> 
+      <div
+        v-if="displayButton"
+        :title="addEventButtonTooltip"
+        class="d-flex align-center">
+        <v-btn
+          :title="$t('agenda.button.addEvent')"
+          icon
+          class="ms-auto"
+          max-width="28"
+          max-height="28"
+          @click="openEventForm">
+          <v-icon size="20" class="icon-default-color icon-default-size">
+            fas fa-plus
+          </v-icon>
+        </v-btn>
+      </div>
       <v-btn
-        :title="$t('agenda.button.addEvent')"
+        v-if="displaySeeMore && ($root.isMobile || !$root.hover)"
+        ref="moreButton"
+        class="flex-shrink-0 flex-grow-0 px-0 ps-3"
+        color="primary"
+        height="28"
+        text
+        @click="openSeeMoreLink">
+        {{ $t('agenda.timeline.seeMore') }}
+      </v-btn>
+      <v-btn
+        v-if="!$root.isMobile && $root.hover && displaySeeMore"
+        id="agendaTimeLinerxtarnalLinkButton"
+        :title="$t('agenda.timeline.seeMore.tooltip')"
+        color="primary"
         icon
-        class="ms-auto"
         max-width="28"
         max-height="28"
-        @click="openEventForm">
-        <v-icon size="20" class="icon-default-color icon-default-size">
-          fas fa-plus
-        </v-icon>
+        @click="openSeeMoreLink">
+        <v-icon size="20">fa-external-link-alt</v-icon>
+      </v-btn>
+      <v-btn
+        v-if="!$root.isMobile && $root.hover && $root.canEdit"
+        id="agendaTimeLineSettingsButton"
+        :title="$t('agenda.settings.button.tooltip')"
+        max-width="28"
+        max-height="28"
+        icon
+        @click="$root.$emit('open-agenda-timeline-settings')">
+        <v-icon size="20">fa-cog</v-icon>
       </v-btn>
     </div>
-    <v-btn
-      v-if="displaySeeMore && ($root.isMobile || !$root.hover)"
-      ref="moreButton"
-      class="flex-shrink-0 flex-grow-0 px-0 ps-3"
-      color="primary"
-      height="28"
-      text
-      @click="openSeeMoreLink">
-      {{ $t('agenda.timeline.seeMore') }}
-    </v-btn>
-    <v-btn
-      v-if="!$root.isMobile && $root.hover && displaySeeMore"
-      id="agendaTimeLinerxtarnalLinkButton"
-      :title="$t('agenda.timeline.seeMore.tooltip')"
-      color="primary"
-      icon
-      max-width="28"
-      max-height="28"
-      @click="openSeeMoreLink">
-      <v-icon size="20">fa-external-link-alt</v-icon>
-    </v-btn>
-    <v-btn
-      v-if="!$root.isMobile && $root.hover && $root.canEdit"
-      id="agendaTimeLineSettingsButton"
-      :title="$t('agenda.settings.button.tooltip')"
-      max-width="28"
-      max-height="28"
-      icon
-      @click="$root.$emit('open-agenda-timeline-settings')">
-      <v-icon size="20">fa-cog</v-icon>
-    </v-btn>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Prior to this fix, when the title on the timeline portlet id too long, it's displayed on several lines and centered. This commit fix this by applying an ellipsis.