### PR TITLE
fix:  Display event of other month for few millisecond - EXO-86447

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -212,13 +212,11 @@ export default {
     });
     this.$root.$on('agenda-display-calendar-next', () => {
       if (this.$refs.calendar) {
-        this.events = [];
         this.$refs.calendar.next();
       }
     });
     this.$root.$on('agenda-display-calendar-previous', () => {
       if (this.$refs.calendar) {
-        this.events = [];
         this.$refs.calendar.prev();
       }
     });

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -212,11 +212,13 @@ export default {
     });
     this.$root.$on('agenda-display-calendar-next', () => {
       if (this.$refs.calendar) {
+        this.events = [];
         this.$refs.calendar.next();
       }
     });
     this.$root.$on('agenda-display-calendar-previous', () => {
       if (this.$refs.calendar) {
+        this.events = [];
         this.$refs.calendar.prev();
       }
     });

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -148,6 +148,7 @@ export default {
       }
     },
     period() {
+      this.events = [];
       this.retrieveEvents();
       if (this.settings.showRemoteEventsForTimeLine && this.signedInConnector) {
         this.retrieveRemoteEvents();

--- a/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
@@ -186,6 +186,7 @@ export default {
       }
     },
     period() {
+      this.events = [];
       this.retrieveEvents();
       if (this.settings.showRemoteEventsForAgenda && this.signedInConnector) {
         this.retrieveRemoteEvents();


### PR DESCRIPTION
Prior to this fix, when the period is changed on the month view, the events of the next or previous month are displayed for a few milliseconds.
This commit fixes this by resetting the list of events on period change.