### PR TITLE
fix: Date selector does not change the calendar in SM mode for Agenda app - EXO-87142

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaHeader.vue
@@ -24,7 +24,7 @@
         :offset-x="offsetX"
         :offset-y="offsetY"
         width="36"
-        height="36"/>
+        height="36" />
       <extension-registry-components
         :params="params"
         name="AgendaApp"
@@ -102,8 +102,12 @@ export default {
         return;
       }
       if (this.$agendaUtils.toRFC3339(oldVal, true) !== this.$agendaUtils.toRFC3339(newVal, true)) {
-        this.period.start = this.periodStart;
-        this.$root.$emit('agenda-refresh');
+        if (this.$root.isMobile) {
+          this.period.start = this.periodStart;
+          this.$root.$emit('agenda-refresh');
+        } else {
+          this.$root.$emit('agenda-display-calendar-atDate', this.$agendaUtils.toRFC3339(newVal, true));
+        }
       }
     },
   },


### PR DESCRIPTION
Prior to this fix, when the date is changed in the Agenda app with the date selector in SM mode, the calendar is not updated.
This commit fixes this by setting the current date of the calendar to be updated.