### PR TITLE
fix: Agenda timeline - Behavior when no event displayed - EXO-87083

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaEmptyTimeline.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaEmptyTimeline.vue
@@ -1,13 +1,51 @@
 <template>
-  <v-sheet class="d-flex flex-column justify-center align-center fill-height z-index-one" max-height="100%">
+  <v-sheet class="d-flex flex-column justify-center align-center fill-height z-index-one pa-5" max-height="100%">
     <v-icon
       color="secondary"
       size="60"
       class="mb-2">
       fas fa-calendar
     </v-icon>
-    <p class="mt-2 mb-0 text-sub-title">
-      {{ $t('agenda.label.start.adding.events') }}
-    </p>
+    <div class="d-flex flex-grow-1 my-3 align-center justify-center">
+      <v-btn
+        v-if="displayAddEvent"
+        class="btn btn-primary"
+        outlined
+        @click="openEventForm">
+        {{ $t('agenda.title.addEvent') }}
+      </v-btn>
+    </div>
   </v-sheet>
 </template>
+<script>
+export default {
+  props: {
+    canCreateEvent: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    displayAddEvent() {
+      return this.canCreateEvent &&  this.$root.timelineSettings.displayAddEvent !== false;
+    },
+  },  
+
+  methods: {
+    openEventForm() {
+      this.$root.$emit('agenda-event-quick-form', {
+        summary: '',
+        startDate: new Date(),
+        endDate: new Date(),
+        allDay: false,
+        calendar: {
+          owner: {},
+        },
+        reminders: [],
+        attachments: [],
+        attendees: [],
+      });
+    },
+  },
+};
+</script>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
@@ -77,7 +77,7 @@
       </v-list>
     </template>
   </v-flex>
-  <agenda-empty-timeline v-else-if="!loading" />
+  <agenda-empty-timeline v-else-if="!loading" :can-create-event="canCreateEvent" />
 </template>
 <script>
 export default {
@@ -105,6 +105,10 @@ export default {
     connectedConnectorAvatar: {
       type: String,
       default: null
+    },
+    canCreateEvent: {
+      type: Boolean,
+      default: false,
     },
   },
   data: () => ({

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineHeader.vue
@@ -77,6 +77,10 @@ export default {
       type: Object,
       default: null
     },
+    eventsCount: {
+      type: Number,
+      default: 0,
+    },
     calendars: {
       type: Array,
       default: () => []
@@ -101,6 +105,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    canCreateEvent: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     initialized: false,
@@ -110,16 +118,13 @@ export default {
       return this.$root.timelineSettings.customHeader && this.$root.headerTitle!=='null' ? this.$root.headerTitle : this.$t('agenda');
     },
     displayButton() {
-      return (this.initialized || !eXo.env.portal.spaceId) && !this.$root.isMobile && this.canCreateEvent &&  this.$root.timelineSettings.displayAddEvent !== false;
+      return this.eventsCount > 0 && (this.initialized || !eXo.env.portal.spaceId) && !this.$root.isMobile && this.canCreateEvent &&  this.$root.timelineSettings.displayAddEvent !== false;
     },
     displaySeeMore() {
       return this.$root.timelineSettings.displaySeeMore !== false ;
     },
     displayPendingEvents() {
       return this.$root.timelineSettings.displayPending;
-    },
-    canCreateEvent() {
-      return (this.$root?.timelineSettings && this.$root.timelineSettings.agendaSource !== 'selectedSpaces') || (this.calendars?.length && this.calendars.some(c => c?.acl?.canCreate));
     },
     addEventButtonTooltip() {
       if (!this.canCreateEvent) {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -4,7 +4,9 @@
       <v-card class="d-flex flex-column application-body position-static border-box-sizing" flat>
         <agenda-timeline-header
           :current-space="currentSpace"
+          :events-count="displayedEvent.length"
           :calendars="calendars"
+          :can-create-event="canCreateEvent"
           :agenda-base-link="agendaBaseLink"
           :connectors="enabledConnectors"
           :settings="settings"
@@ -15,6 +17,7 @@
           :events="displayedEvent"
           :period-start-date="periodStart"
           :agenda-base-link="agendaBaseLink"
+          :can-create-event="canCreateEvent"
           :loading="loading || !initialized"
           :limit="limit"
           :connected-connector-avatar="connectedConnectorAvatar" />
@@ -85,6 +88,9 @@ export default {
     periodTitle: '',
   }),
   computed: {
+    canCreateEvent() {
+      return (this.$root?.timelineSettings && this.$root.timelineSettings.agendaSource !== 'selectedSpaces') || (this.calendars?.length && this.calendars.some(c => c?.acl?.canCreate));
+    },
     enabledConferenceProviderName() {
       return this.settings
               && this.conferenceProviders


### PR DESCRIPTION
Prior to this fix, in the agenda timeline portlet, when there are no events, the + button is displayed and a placeholder with a label that is not the same as other portlets.
 This commit hides the + button in the header and replaces the label Add event by a CTA "add event".