### PR TITLE
fix: Avoid fetching event when no eventId available in event content extensions - EXO-87209

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/activity-stream-extensions/components/ContentActivityEventDate.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/activity-stream-extensions/components/ContentActivityEventDate.vue
@@ -62,6 +62,9 @@ export default {
   },
   methods: {
     async init() {
+      if (!this.eventId) {
+        return;
+      }
       this.loading = true;
       this.event = null;
       try {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/content-list-extensions/components/ContentCardEventDateChip.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/content-list-extensions/components/ContentCardEventDateChip.vue
@@ -101,6 +101,9 @@ export default {
   },
   methods: {
     async init() {
+      if (!this.eventId) {
+        return;
+      }
       this.loading = true;
       this.event = null;
       try {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/content-publication-extensions/components/ContentEventDisplayReminder.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/content-publication-extensions/components/ContentEventDisplayReminder.vue
@@ -489,6 +489,9 @@ export default {
       this.event = null;
     },
     async init() {
+      if (!this.eventId) {
+        return;
+      }
       this.loading = true;
       this.event = null;
       try {


### PR DESCRIPTION
Avoid fetching event when no eventId available in event content extensions