### PR TITLE
fix: UI Issue on agenda app header at first load - EXO-8553

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -678,8 +678,8 @@
 }
 
 .v-calendar-daily__head {
-  margin-right: 5 !important; /** orientation=rt */
-  margin-left: 14px !important; /** orientation=rt */
+  margin-right: 5px !important; /** orientation=rt */
+  margin-left: 0px !important; /** orientation=rt */
 }
 
 .agenda-date-poll-details-mobile {

--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -678,8 +678,8 @@
 }
 
 .v-calendar-daily__head {
-  margin-right:  ~'0 !important; /** orientation=rt */ ';
-  margin-left: ~'14px !important; /** orientation=rt */ ';
+  margin-right: 5 !important; /** orientation=rt */
+  margin-left: 14px !important; /** orientation=rt */
 }
 
 .agenda-date-poll-details-mobile {


### PR DESCRIPTION
Prior to this fix,  there is a shift of the header (day line) compared to the time columns.
This commit fix this issue by applying the good margin to the agenda head