### PR TITLE
fix: Support emoji in agenda event summary on MySQL - EXO-87687

### DIFF
--- a/agenda-services/src/main/resources/db/changelog/agenda-rdbms.db.changelog.xml
+++ b/agenda-services/src/main/resources/db/changelog/agenda-rdbms.db.changelog.xml
@@ -410,4 +410,10 @@
     </sql>
   </changeSet>
 
+  <changeSet author="agenda" id="1.0.0-35" dbms="mysql">
+    <sql>
+      ALTER TABLE EXO_AGENDA_EVENT MODIFY SUMMARY TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
MySQL's utf8 charset cannot store 4-byte emoji characters. Added Liquibase changeSet to alter EXO_AGENDA_EVENT.SUMMARY to utf8mb4.