### PR TITLE
fix: Events displayed above date picker in agenda app - EXO-87486

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaHeader.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaHeader.vue
@@ -12,6 +12,7 @@
         <date-picker
           v-if="$root.isMobile || $root.isTablet"
           v-model="periodStart"
+          :attach="false"
           class="agenda-header-date-picker z-index-two" />  
         <agenda-period-selector
           v-else


### PR DESCRIPTION
Prior to this fix, multi-day events are displayed above the date picker in the agenda app. 
This commit fixes this issue by setting the attachprop of the date picker to false.