### PR TITLE
fix: Agenda timeline default settings for existing spaces - EXO-87774

### DIFF
--- a/agenda-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -54,7 +54,7 @@
                    "seeMoreUrl":"",
                    "displayPending":true,
                    "displayAddEvent": true,
-                   "agendaFilter": 'allEvents',
+                   "agendaFilter": '',
                    "itemsNumber": 10
                    }
                </value>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
@@ -309,7 +309,11 @@ export default {
         this.timelineSettings.itemsNumber = 10;
       }
       if (!this.timelineSettings.agendaFilter) {
-        this.timelineSettings.agendaFilter = 'allEvents';
+        if (eXo.env.portal.spaceId) {  
+          this.timelineSettings.agendaFilter = 'allEvents';
+        } else {
+          this.timelineSettings.agendaFilter = 'acceptedEvents';
+        }
       }
       this.defaultTimelineSettings = JSON.parse(JSON.stringify(this.timelineSettings));
       this.$refs.drawer.open();

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -302,8 +302,16 @@ export default {
     },
     retrieveEventsFromStore() {
       this.loading = true;
-      const userIdentityId = this.$root.timelineSettings.agendaFilter === 'acceptedEvents' && eXo.env.portal.userIdentityId || null;
-      const responseTypes = this.$root.timelineSettings.agendaFilter === 'acceptedEvents' ? ['ACCEPTED'] : ['ACCEPTED', 'NEEDS_ACTION', 'TENTATIVE'];
+      let agendaFilter = this.$root.timelineSettings.agendaFilter;
+      if (!agendaFilter) {
+        if (eXo.env.portal.spaceId) {  
+          agendaFilter = 'allEvents';
+        } else {
+          agendaFilter = 'acceptedEvents';
+        }
+      }
+      const userIdentityId = agendaFilter === 'acceptedEvents' && eXo.env.portal.userIdentityId || null;
+      const responseTypes = agendaFilter === 'acceptedEvents' ? ['ACCEPTED'] : ['ACCEPTED', 'NEEDS_ACTION', 'TENTATIVE'];
       return this.$eventService.getEvents(this.searchTerm, this.ownerIds, userIdentityId, this.$agendaUtils.toRFC3339(this.period.start, false), this.$agendaUtils.toRFC3339(this.period.end), this.limit, responseTypes, 'attendees,conferences')
         .then(data => {
           const events = data && data.events || [];


### PR DESCRIPTION
Prior to this fix,  for agenda timeline added outside spaces, the default settings for "filter agenda" is "All events". This commit change this by setting the filter to "Accepted events" outside space.