### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/analytics/AgendaEventResponseListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/analytics/AgendaEventResponseListener.java
@@ -77,8 +77,8 @@ public class AgendaEventResponseListener  extends Listener<Long, Object> {
     if (userId > 0) {
       statisticData.setUserId(userId);
     }
-    statisticData.addParameter("eventId", agendaEvent.getId());
-    statisticData.addParameter("eventResponse", eventResponse);
+    statisticData.addLong("eventId", agendaEvent.getId());
+    statisticData.addKeyword("eventResponse", eventResponse);
     AnalyticsUtils.addStatisticData(statisticData);
   }
 

--- a/agenda-services/src/main/java/org/exoplatform/agenda/listener/analytics/AgendaSavedEventListener.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/listener/analytics/AgendaSavedEventListener.java
@@ -83,15 +83,15 @@ public class AgendaSavedEventListener extends Listener<AgendaEventModification, 
     statisticData.setSubModule("event");
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
-    statisticData.addParameter("eventId", event.getId());
-    statisticData.addParameter("parentId", event.getParentId());
-    statisticData.addParameter("calendarOwnerIdentityId", calendarOwnerId);
-    statisticData.addParameter("creatorId", event.getCreatorId());
-    statisticData.addParameter("modifierId", event.getModifierId());
-    statisticData.addParameter("eventStatus", event.getStatus());
-    statisticData.addParameter("isRecurrent", event.getRecurrence() != null);
-    statisticData.addParameter("isExceptionalOccurrence", event.getOccurrence() != null);
-    statisticData.addParameter("eventModificationTypes", eventModification.getModificationTypes());
+    statisticData.addKeyword("eventId", event.getId());
+    statisticData.addKeyword("eventParentId", event.getParentId());
+    statisticData.addKeyword("calendarOwnerIdentityId", calendarOwnerId);
+    statisticData.addKeyword("creatorId", event.getCreatorId());
+    statisticData.addKeyword("modifierId", event.getModifierId());
+    statisticData.addKeyword("eventStatus", event.getStatus());
+    statisticData.addBoolean("isRecurrent", event.getRecurrence() != null);
+    statisticData.addBoolean("isExceptionalOccurrence", event.getOccurrence() != null);
+    statisticData.addKeyword("eventModificationTypes", eventModification.getModificationTypes());
     AnalyticsUtils.addStatisticData(statisticData);
   }
 


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.