### PR TITLE
fix: Remove background of X more event label in month view with small screen - EXO-87766

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -139,6 +139,10 @@
           font-size: 12px !important;
           }
         }
+
+        .v-event-more {
+          background-color: transparent;
+        }
       }
     }
 


### PR DESCRIPTION
Prior to this fix,  when the label "X more" is showed nit have a white background. The background hides the border and the "all day" event. 
This commit fixes this by changing the background color ot the label to transparent.