### PR TITLE
fix: Avoid Updating TimeZone of Anonymous Users - EXO-87799

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-base-extension/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-base-extension/main.js
@@ -1,5 +1,5 @@
 const timeZoneId = new window.Intl.DateTimeFormat().resolvedOptions().timeZone;
-if (eXo.env.portal.userTimezone !== timeZoneId) {
+if (eXo.env.portal.userName && eXo.env.portal.userTimezone !== timeZoneId) {
   fetch('/agenda/rest/timezone', {
     headers: {
       'Content-Type': 'text/plain',


### PR DESCRIPTION
Prior to this change, when displaying a public page by anonymous user, the page attempts to update the anonymous user TimeZone which leads to a 404 HTTP error. This change avoid updating the timezone of anonymous users in public pages like login page.