### PR TITLE
fix: Text spacing properties cannot be redefined without loss of readability - EXO-85713

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -749,6 +749,8 @@
     margin-top: 7px!important;
     margin-right: 8px!important;
     white-space: pre-line;
+    word-break: normal; 
+    overflow-wrap: normal;
   }
   .event-timeline-detail-content {
     min-width: 100%;


### PR DESCRIPTION
Prior to this fix,  when text spacing properties are redefined, dates are becoming unreadable since splitted inside the day name. 
This commit fixes this by updating CSS to avoid splitting the displayed date anywhere.