### PR TITLE
fix: Visio URL auto-creation doesn't work when Pexip is disabled - EXO-87840

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda/components/Agenda.vue
@@ -130,7 +130,7 @@ export default {
       return this.settings
           && this.conferenceProviders
           && this.conferenceProviders.length > 0
-          && this.conferenceProviders.find((provider) => provider.configured);
+          && this.conferenceProviders.find((provider) => provider.isInitialized && provider.configured);
     },
     conferenceProvider() {
       return this.conferenceProviders && this.enabledConferenceProviderName && this.conferenceProviders.find(provider => provider.isInitialized && provider.linkSupported && provider.groupSupported && this.enabledConferenceProviderName.getType() === provider.getType());


### PR DESCRIPTION
Before this change, when go to admin-application-visio and disable pexip and go to spaceX and create event, visio url creation button not displayed. To fix this issue, the filtering logic for enabledConferenceProviderNames was updated to only consider the provider that is properly initialized. After this change, as jitsi enabled, the visio url creation button is available.