### PR TITLE
fix: Recurrent event with end date not synchronized in google calendar - EXO-72273

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -246,15 +246,16 @@ public class Utils {
   public static Recur getICalendarRecur(EventRecurrence recurrence, ZoneId zoneId) {
     Recur.Builder recurBuilder = new Recur.Builder();
     recurBuilder.frequency(Frequency.valueOf(recurrence.getFrequency().name()));
-    recurBuilder.count(recurrence.getCount() > 0 ? recurrence.getCount() : 0);
     recurBuilder.interval(recurrence.getInterval());
-    if (recurrence.getUntil() != null) {
+    if (recurrence.getCount() > 0) {
+      recurBuilder.count(recurrence.getCount() > 0 ? recurrence.getCount() : 0);
+    } else if (recurrence.getUntil() != null) {
+      ZoneId effectiveZoneId = zoneId != null ? zoneId : ZoneOffset.UTC;
       DateTime dateTime = new DateTime(AgendaDateUtils.toDate(recurrence.getUntil()
-                                                                        .atStartOfDay(zoneId)
-                                                                        .plusDays(1)
-                                                                        .minusSeconds(1)));
-      TimeZone ical4jTimezone = getICalTimeZone(zoneId == null ? ZoneOffset.UTC : zoneId);
-      dateTime.setTimeZone(ical4jTimezone);
+        .atStartOfDay(effectiveZoneId)
+        .plusDays(1)
+        .minusSeconds(1)));
+      dateTime.setUtc(true);
       recurBuilder.until(dateTime);
     }
     if (recurrence.getBySecond() != null && !recurrence.getBySecond().isEmpty()) {


### PR DESCRIPTION
Before this change, creating an event with custom recurrency with an end date and checking Google Calendar showed no synchronization. The RRULE generated contained COUNT=0 alongside UNTIL, and the UNTIL value was missing the required UTC Z suffix, causing Google Calendar API to reject the recurrence rule with a 400 Invalid recurrence rule error. To fix this issue, COUNT is now only set when UNTIL is absent (RFC 5545 forbids both in the same rule), and setUtc(true) is called on the UNTIL DateTime so iCal4j serializes it with the required Z suffix. After this change, the event is synchronized in Google Calendar.