### PR TITLE
fix: No synchronization with personal google calendar when transforming a date poll to an event - EXO-45672

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaDatePollActionButtons.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/date-poll/AgendaDatePollActionButtons.vue
@@ -89,6 +89,13 @@ export default {
         .then(() => {
           this.$root.$emit('agenda-refresh');
           window.setTimeout(() => this.$root.$emit('agenda-event-details', this.event), 200);
+          this.$eventService.getEventById(dateOption.eventId, 'all')
+            .then(event => {
+              if (!event) {
+                return;
+              }
+              this.$root.$emit('agenda-event-response-updated', event, null, 'ACCEPTED');
+            });
         })
         .finally(() => {
           window.setTimeout(() => {


### PR DESCRIPTION
Prior to this fix,  When transforming a date poll to an event , the created event is not synchronized automatically in google calendar. This commit fixes this by pushing the event to the remote calender when the poll is voted.

(cherry picked from commit af856cc60f0b87a77ba9c7ed54ea4a22fa5e1a5a)