### PR TITLE
fix: Can't edit the time of an all day recuring event - EXO-51336 (#966)

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/confirm-dialog/AgendaRecurrentEventSaveConfirmDialog.vue
@@ -113,6 +113,7 @@ export default {
                 recurrentEvent.description = this.event.description;
                 recurrentEvent.location = this.event.location;
                 recurrentEvent.summary = this.event.summary;
+                recurrentEvent.dateOptions = this.event.dateOptions || [];
                 if (this.event.recurrence) {
                   recurrentEvent.recurrence = this.event.recurrence;
                 } else {


### PR DESCRIPTION
Prior to this change, when attempting to update a recurrence of an all-day event, the newly selected date options were not saved due to missing event date options properties. This change ensures that these properties are properly set, resolving the issue.