### PR TITLE
fix: Waiting event number truncated - EXO-87875 (#975)

### DIFF
--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -146,15 +146,18 @@
       }
     }
 
-    .pending-invitation-badge .v-badge__badge {
-      max-width: 20px;
-      max-height: 20px;
-      line-height: 20px;
-      padding: 0;
-      position: absolute;
-      top: -7px !important;
-      right: -12px !important;
-      left: auto !important;
+    .pending-invitation-badge {
+      margin-top: 2px;
+      .v-badge__badge {
+        max-width: 20px;
+        max-height: 20px;
+        line-height: 20px;
+        padding: 0;
+        position: absolute;
+        top: -7px !important;
+        right: -12px !important;
+        left: auto !important;
+     }
     }
     .create-event-dialog {
       overflow: hidden !important;


### PR DESCRIPTION
Prior to this fix, The number waiting event indicator is truncated at the top. This commit fixes this by fixing the the badge margin.

(cherry picked from commit a3d337ba1f285f030e4b6034c7557b414be1a72f)