### PR TITLE
fix: unable to create an event poll when using webconf connector which needs event startDate and endDate - EXO-88321

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventService.js
@@ -346,6 +346,11 @@ export function selectEventDate(eventId, dateOptionId) {
     .then((resp) => {
       if (!resp || !resp.ok) {
         throw new Error('Error selecting an event date');
+      } else {
+        getEventById(eventId,'all').then(event => {
+          const saveWebConferencePromises = getSaveAllWebConferencesPromises(event);
+          return Promise.all(saveWebConferencePromises);
+        });
       }
     });
 }

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/EventWebConferencingService.js
@@ -61,7 +61,7 @@ function createConference(event, conference) {
       const participants = identities.filter(identity => identity && identity.providerId === 'organization' && identity?.profile?.dataEntity?.enabled).map(identity => identity.remoteId);
       const spaces = identities.filter(identity => identity && identity.providerId === 'space').map(identity => identity.remoteId);
       const startDate = new Date(event.start);
-      const endDate = event.endDate && new Date(event.end) || event.recurrence && event.recurrence.until && new Date(event.recurrence.until) || null;
+      const endDate = event.end && new Date(event.end) || event.recurrence && event.recurrence.until && new Date(event.recurrence.until) || null;
       return global.webConferencing.addCall({
         title: event.title,
         owner: event.calendar.owner.id,


### PR DESCRIPTION
Before this fix, the endDate if not correctly computed in case of event poll, which lead to a js error. This fix ensure to use the correct value to compute endDate In addition, when the pool date is choosen, this commit ensure to update the conferences associated to the event.