### PR TITLE
feat: Manage participation while viewing and editing - EXO-88080

### DIFF
--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
@@ -338,7 +338,8 @@ agenda.button.joinMeeting=Join the meeting
 agenda.tooltip.meeting.copyLink=Copy Link
 agenda.message.meetingLinkCopied=Meeting Link Successfully Copied
 
-
-
-
-
+agenda.tooltip.removeParticipant=Remove from participants
+agenda.tooltip.cannotRemoveOwner=Cannot remove
+agenda.attendees.searchPlaceholder=Search for space or users
+agenda.label.participants=Participants List
+agenda.label.addParticipants=Add

--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -287,6 +287,13 @@
       min-width: 120px;
     }
   }
+  .attendee-status-badges .v-badge__badge {
+    font-size: 9px;
+    height: 14px;
+    min-width: 14px;
+    padding: 0;
+    line-height: 14px;
+  }
 
   .event-form-mobile {
     max-height: 100%;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/common/AgendaEventAttendeesAvatars.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/common/AgendaEventAttendeesAvatars.vue
@@ -1,0 +1,88 @@
+<template>
+   <v-card
+    :min-width="avatarsWidth"
+    class="transparent d-flex align-center"
+    flat
+    tabindex="0"
+    min-height="42"
+    @mouseenter="showSeeMore = true"
+    @mouseleave="showSeeMore = false"
+    @focusin="showSeeMore = true"
+    @focusout="showSeeMore = false">
+    <div v-if="!showSeeMore" class="d-flex align-center">
+      <v-avatar
+        v-for="(attendee, index) in visibleAttendees"
+        :key="attendee.identity.id || attendee.identity.remoteId"
+        :tile="attendee.identity.providerId === 'space'"
+        :class="[index > 0 && 'ms-n3', attendee.identity.providerId === 'space' && 'rounded']"
+        :size="size"
+        class="border-white">
+        <v-img 
+          :src="attendeeAvatarUrl(attendee)" 
+          :lazy-src="defaultAvatarUrl" 
+          eager />
+      </v-avatar>
+      <v-avatar
+        v-if="overflowCount > 0"
+        :size="size"
+        class="ms-n3 grey-lighten1-background border-white">
+        <span class="text-body white--text text-center">+{{ overflowCount }}</span>
+      </v-avatar>
+    </div>
+    <v-btn
+      v-else
+      :min-width="avatarsWidth"
+      :min-height="size"
+      class="caption white--text grey-lighten1-background px-1"
+      v-ripple="false"
+      text
+      @click.stop="$emit('open')">
+      <span class="text-body white--text text-center">{{ $t('agenda.timeline.seeMore') }}</span>
+    </v-btn>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    attendees: {
+      type: Array,
+      default: () => [],
+    },
+    max: {
+      type: Number,
+      default: 3,
+    },
+    size: {
+      type: Number,
+      default: 34,
+    },
+  },
+  data() {
+    return {
+      showSeeMore: false,
+    };
+  },
+  computed: {
+    visibleAttendees() {
+      return this.attendees.slice(0, this.max);
+    },
+    overflowCount() {
+      return Math.max(0, this.attendees.length - this.max);
+    },
+    avatarsWidth() {
+      const count = Math.min(this.attendees.length, this.max) + (this.overflowCount > 0 ? 1 : 0);
+      return this.size + (count - 1) * (this.size - 12) + (count * 2);
+    },
+    defaultAvatarUrl() {
+      return '/portal/rest/v1/social/users/default-image/avatar';
+    },
+  },
+  methods: {
+    attendeeAvatarUrl(attendee) {
+      const profile = attendee.identity.profile || attendee.identity.space || {};
+      return profile.avatar || profile.avatarUrl || '/portal/rest/v1/social/users/default-image/avatar';
+    },
+  },
+};
+</script>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendeeItem.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendeeItem.vue
@@ -1,15 +1,57 @@
 <template>
-  <v-chip
-    :close="canRemoveAttendee"
-    class="identitySuggesterItem me-4 mt-4"
-    @click:close="$emit('remove-attendee', attendee)">
-    <v-avatar left>
-      <v-img :src="avatarUrl" />
-    </v-avatar>
-    <span class="text-truncate">
-      {{ displayName }}
-    </span>
-  </v-chip>
+  <v-list-item class="px-0">
+    <v-list-item-avatar
+      :tile="isSpace"
+      :class="isSpace && 'rounded'"
+      size="36"
+      class="me-2 my-1 flex-shrink-0">
+      <v-img
+        :src="avatarUrl"
+        :lazy-src="defaultAvatarUrl" />
+    </v-list-item-avatar>
+    <v-list-item-content class="py-1">
+      <v-list-item-title>
+        <span class="text-truncate">{{ displayName }}</span>
+      </v-list-item-title>
+    </v-list-item-content>
+    <v-list-item-action class="d-flex flex-row align-center my-0">
+      <v-tooltip v-if="isOwner" bottom>
+        <template #activator="{ on }">
+          <v-icon
+            size="14"
+            class="me-1 yellow--text text--darken-2"
+            v-on="on">
+            fas fa-crown
+          </v-icon>
+        </template>
+        <span>{{ $t('agenda.eventCreator') }}</span>
+      </v-tooltip>
+      <v-tooltip v-if="attendee.response" bottom>
+        <template #activator="{ on }">
+          <v-icon :color="responseColor" size="18" class="me-1" v-on="on">
+            {{ responseIcon }}
+          </v-icon>
+        </template>
+        <span>{{ responseLabel }}</span>
+      </v-tooltip>
+      <v-tooltip v-if="editable" bottom>
+        <template #activator="{ on }">
+          <span v-on="on">
+            <v-btn
+              :disabled="isOwner"
+              icon
+              x-small
+              @click="!isOwner && $emit('remove-attendee', attendee)">
+              <v-icon size="16" :color="isOwner ? 'grey lighten-1' : 'red'">
+                fas fa-trash-alt
+              </v-icon>
+            </v-btn>
+          </span>
+        </template>
+        <span>{{ isOwner ? $t('agenda.tooltip.cannotRemoveOwner') : $t('agenda.tooltip.removeParticipant') }}</span>
+      </v-tooltip>
+    </v-list-item-action>
+  </v-list-item>
 </template>
 
 <script>
@@ -23,18 +65,27 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    editable: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
-    canRemoveAttendee() {
+    defaultAvatarUrl() {
+      return '/portal/rest/v1/social/users/default-image/avatar';
+    },
+    isSpace() {
+      return !!(this.attendee.identity && this.attendee.identity.providerId === 'space');
+    },
+    isOwner() {
       if (this.creator && this.creator.id) {
-        return Number(this.attendee.identity.id) !== Number(this.creator.id);
-      } else {
-        return Number(this.attendee.identity.id) !== Number(eXo.env.portal.userIdentityId);
+        return Number(this.attendee.identity.id) === Number(this.creator.id);
       }
+      return Number(this.attendee.identity.id) === Number(eXo.env.portal.userIdentityId);
     },
     avatarUrl() {
       const profile = this.attendee.identity && (this.attendee.identity.profile || this.attendee.identity.space);
-      return profile && (profile.avatarUrl || profile.avatar || '/portal/rest/v1/social/users/default-image/avatar');
+      return profile && (profile.avatarUrl || profile.avatar) || this.defaultAvatarUrl;
     },
     displayName() {
       const profile = this.attendee.identity && (this.attendee.identity.profile || this.attendee.identity.space);
@@ -42,8 +93,32 @@ export default {
       return this.isExternal ? `${fullName} (${this.$t('profile.External')})` : fullName;
     },
     isExternal() {
-      const profile = this.attendee.identity && this.attendee.identity.profile ;
+      const profile = this.attendee.identity && this.attendee.identity.profile;
       return profile && (profile.dataEntity && profile.dataEntity.external === 'true' || profile.external);
+    },
+    responseIcon() {
+      switch (this.attendee.response) {
+      case 'ACCEPTED': return 'fas fa-check-circle';
+      case 'TENTATIVE': return 'fas fa-question-circle';
+      case 'DECLINED': return 'fas fa-times-circle';
+      default: return 'fas fa-question-circle';
+      }
+    },
+    responseColor() {
+      switch (this.attendee.response) {
+      case 'ACCEPTED': return 'success';
+      case 'TENTATIVE': return 'blue';
+      case 'DECLINED': return 'error';
+      default: return 'grey';
+      }
+    },
+    responseLabel() {
+      switch (this.attendee.response) {
+      case 'ACCEPTED': return this.$t('agenda.accepted');
+      case 'TENTATIVE': return this.$t('agenda.tentative');
+      case 'DECLINED': return this.$t('agenda.declined');
+      default: return this.$t('agenda.needs_action');
+      }
     },
   },
 };

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendees.vue
@@ -1,34 +1,29 @@
 <template>
-  <v-flex class="user-suggester text-truncate">
-    <form
-      ref="form"
-      @keypress="checkGuestInvitation($event)">
-      <exo-identity-suggester
-        ref="invitedAttendeeAutoComplete"
-        v-model="invitedAttendee"
-        :labels="participantSuggesterLabels"
-        :title="suggesterStatus"
-        :disabled="disableAttendeeSuggester"
-        :ignore-items="ignoredMembers"
-        :search-options="searchOptions"
-        name="inviteAttendee"
-        no-redactor-space
-        include-users
-        include-spaces />
-      <span v-if="disableAttendeeSuggester" class="error--text">
-        {{ $t('agenda.suggesterRequired') }}
-      </span>
-    </form>
-    <agenda-notification-alerts v-if="displayAlert" name="event-form" />
-    <div v-if="event.attendees" class="identitySuggester no-border mt-0">
-      <agenda-event-form-attendee-item
-        v-for="attendee in event.attendees"
-        :key="attendee.identity.id"
-        :attendee="attendee"
-        :creator="event.creator"
-        @remove-attendee="removeAttendee" />
+  <div class="d-flex align-center flex-grow-1">
+    <span class="subtitle-2 me-4">{{ $t('agenda.participants') }}</span>
+    <v-btn
+      :class="sortedAttendees.length > 1 && !event.id || event.id ? '' : 'ms-auto'"
+      :title="$t('agenda.addParticipants')"
+      icon
+      x-small
+      @click="openDrawer">
+      <v-icon class="icon-default-color" size="18">fas fa-plus</v-icon>
+    </v-btn>
+    <div
+      v-if="sortedAttendees.length > 1 && !event.id || event.id"
+      class="ms-auto d-flex align-center">
+      <agenda-event-attendees-avatars
+        v-if="!showSeeMore"
+        :attendees="sortedAttendees"
+        :max="3"
+        :size="34" 
+        @open="openDrawer" />
     </div>
-  </v-flex>
+    <agenda-event-form-attendees-drawer
+      ref="attendeesDrawer"
+      :event="event"
+      @initialized="$emit('initialized')" />
+  </div>
 </template>
 
 <script>
@@ -39,146 +34,46 @@ export default {
       default: () => ({}),
     },
   },
-  data() {
-    return {
-      currentUser: null,
-      invitedAttendee: [],
-    };
-  },
   computed: {
-    searchOptions() {
-      return {
-        currentUser: '',
-        spaceURL: this.event
-          && this.event.calendar
-          && this.event.calendar.owner
-          && this.event.calendar.owner.remoteId,
-      };
-    },
-    participantSuggesterLabels() {
-      return {
-        searchPlaceholder: this.$t('agenda.searchPlaceholder'),
-        placeholder: this.$t('agenda.addParticipants'),
-        noDataLabel: this.$t('agenda.noDataLabel'),
-      };
-    },
-    ignoredMembers() {
-      return this.event.attendees.map(attendee => `${attendee.identity.providerId}:${attendee.identity.remoteId}`);
-    },
-    disableAttendeeSuggester() {
-      if (!this.event.calendar || !this.event.calendar.owner || !this.event.calendar.owner.remoteId) {
-        return true;
-      } else {
-        return false;
-      }
-    },
-    suggesterStatus(){
-      if (this.disableAttendeeSuggester) {
-        return this.$t('agenda.suggesterRequired.tooltip');
-      } else {
-        return '';
-      }
-    }
-  },
-  watch: {
-    currentUser() {
-      this.reset();
-    },
-    invitedAttendee() {
-      if (!this.invitedAttendee) {
-        this.$nextTick(this.$refs.invitedAttendeeAutoComplete.$refs.selectAutoComplete.deleteCurrentItem);
-        return;
-      }
-      if (!this.event.attendees) {
-        this.event.attendees = [];
-      }
-
-      const found = this.event.attendees.find(attendee => {
-        return attendee.identity.remoteId === this.invitedAttendee.remoteId
-          && attendee.identity.providerId === this.invitedAttendee.providerId;
-      });
-      if (!found) {
-        this.event.attendees.push({
-          identity: this.$suggesterService.convertSuggesterItemToIdentity(this.invitedAttendee),
-        });
-      }
-      this.invitedAttendee = null;
+    sortedAttendees() {
+      if (!this.event.attendees) { return []; }
+      const creatorId = this.event.creator && this.event.creator.id;
+      const ownerId = creatorId || eXo.env.portal.userIdentityId;
+      const owner = this.event.attendees.find(a => Number(a.identity.id) === Number(ownerId));
+      const others = this.event.attendees
+        .filter(a => a !== owner)
+        .sort((a, b) => (this.getDisplayName(a) || '').localeCompare(this.getDisplayName(b) || ''));
+      return owner ? [owner, ...others] : others;
     },
   },
-  mounted(){
-    this.reset();
+  mounted() {
     this.$userService.getUser(eXo.env.portal.userName).then(user => {
-      this.currentUser = user;
-      this.$root.$emit('current-user',this.currentUser);
-    });
-  },
-  methods: {
-    reset() {
-      if (!this.event.id && !this.event.occurrence && (!this.event.attendees || !this.event.attendees.length)) { // In case of edit existing event
-        // Add current user as default attendee
-        if (this.currentUser) {
-          this.event.attendees = [{identity: {
+      this.$root.$emit('current-user', user);
+      if (!this.event.id && !this.event.occurrence && (!this.event.attendees || !this.event.attendees.length)) {
+        this.event.attendees = [{
+          identity: {
             id: eXo.env.portal.userIdentityId,
             providerId: 'organization',
             remoteId: eXo.env.portal.userName,
             profile: {
-              avatar: this.currentUser.avatar,
-              fullname: this.currentUser.fullname,
-              external: this.currentUser.external === 'true',
+              avatar: user.avatar,
+              fullname: user.fullname,
+              external: user.external === 'true',
             },
-          }}];
-        } else {
-          this.event.attendees = [];
-        }
+          },
+        }];
       }
       this.$emit('initialized');
+    });
+  },
+  methods: {
+    openDrawer() {
+      this.$refs.attendeesDrawer.open();
     },
-    removeAttendee(attendee) {
-      const index = this.event.attendees.findIndex(addedAttendee => {
-        return attendee.identity.remoteId === addedAttendee.identity.remoteId
-        && attendee.identity.providerId === addedAttendee.identity.providerId;
-      });
-      if (index >= 0) {
-        this.event.attendees.splice(index, 1);
-      }
+    getDisplayName(attendee) {
+      const profile = attendee.identity && (attendee.identity.profile || attendee.identity.space);
+      return profile && (profile.displayName || profile.fullname || profile.fullName) || attendee.identity.remoteId;
     },
-    checkGuestInvitation(evt) {
-      const self=this;
-      $('form').on('focusout', function(event) {
-        setTimeout(function() {
-          if (!event.delegateTarget.contains(document.activeElement)) {
-            self.saveGuestEmail(event);
-          }
-        }, 1);
-      });
-      // eslint-disable-next-line eqeqeq
-      if (evt.key == 'Enter') {
-        evt.preventDefault();
-        this.saveGuestEmail(evt);   }
-      // eslint-disable-next-line eqeqeq
-      if (evt.keyCode == '32') {
-        this.saveGuestEmail(evt);
-      }
-    },
-    saveGuestEmail() {
-      const reg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,24}))$/;
-      const input = this.$refs?.invitedAttendeeAutoComplete?.searchTerm?.toLowerCase();
-      const words = input!== null ? input.split(' ') : '';
-      const email = words[words.length - 1];
-      if (reg.test(email)) {
-        this.event.attendees.push({identity: {
-          id: `${email}`,
-          remoteId: email,
-          identityId: email,
-          providerId: 'GUEST_USER',
-          profile: {
-            fullName: email,
-            avatarUrl: '/portal/rest/v1/social/users/default-image/avatar',
-          },
-        }});
-      }
-      this.$refs.invitedAttendeeAutoComplete.clear();
-    },
-  }
+  },
 };
 </script>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendeesDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormAttendeesDrawer.vue
@@ -1,0 +1,227 @@
+<template>
+  <exo-drawer
+    ref="attendeesDrawer"
+    right
+    body-classes="hide-scroll decrease-z-index-more"
+    @closed="$emit('closed')">
+    <template slot="title">
+      {{ $t('agenda.label.participants') }}
+    </template>
+    <template slot="content">
+      <div class="pa-4">
+        <template v-if="editable">
+          <div v-if="!showSuggester">
+            <v-btn
+              color="primary"
+              small
+              class="mb-4"
+              @click="showSuggester = true">
+              <v-icon size="12" class="me-1">fas fa-plus</v-icon>
+              {{ $t('agenda.label.addParticipants') }}
+            </v-btn>
+          </div>
+          <form
+            v-else
+            ref="form"
+            class="mb-4"
+            @keypress="checkGuestInvitation($event)">
+            <div class="d-flex align-center">
+              <v-btn icon x-small class="me-2 flex-shrink-0" @click="showSuggester = false">
+                <v-icon size="16" class="icon-default-color">fas fa-arrow-left</v-icon>
+              </v-btn>
+              <exo-identity-suggester
+                ref="invitedAttendeeAutoComplete"
+                v-model="invitedAttendee"
+                :labels="participantSuggesterLabels"
+                :title="suggesterStatus"
+                :disabled="disableAttendeeSuggester"
+                :ignore-items="ignoredMembers"
+                :search-options="searchOptions"
+                name="inviteAttendee"
+                no-redactor-space
+                include-users
+                dense
+                include-spaces />
+            </div>
+            <span v-if="disableAttendeeSuggester" class="error--text caption">
+              {{ $t('agenda.suggesterRequired') }}
+            </span>
+          </form>
+        </template>
+        <div v-if="event && event.attendees" class="mt-2">
+          <agenda-event-form-attendee-item
+            v-for="attendee in displayedAttendees"
+            :key="attendee.identity.id || attendee.identity.remoteId"
+            :attendee="attendee"
+            :creator="event.creator"
+            :editable="editable"
+            @remove-attendee="removeAttendee" />
+          <div v-if="hasMore" class="d-flex justify-center py-2">
+            <v-btn text small @click="loadMore">
+              {{ $t('agenda.button.loadMore') }}
+            </v-btn>
+          </div>
+        </div>
+      </div>
+    </template>
+  </exo-drawer>
+</template>
+
+<script>
+const PAGE_SIZE = 20;
+
+export default {
+  props: {
+    event: {
+      type: Object,
+      default: () => ({}),
+    },
+    editable: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data() {
+    return {
+      invitedAttendee: null,
+      displayedCount: PAGE_SIZE,
+      showSuggester: false,
+    };
+  },
+  computed: {
+    sortedAttendees() {
+      const attendees = this.event && this.event.attendees || [];
+      if (!attendees.length) {
+        return [];
+      }
+      const creatorId = (this.event && this.event.creator && this.event.creator.id)
+        || eXo.env.portal.userIdentityId;
+      const owner = attendees.find(a => Number(a.identity.id) === Number(creatorId));
+      const others = attendees
+        .filter(a => Number(a.identity.id) !== Number(creatorId))
+        .sort((a1, a2) => {
+          const n1 = (a1.identity.profile && (a1.identity.profile.fullname || a1.identity.profile.fullName))
+            || (a1.identity.space && a1.identity.space.displayName) || '';
+          const n2 = (a2.identity.profile && (a2.identity.profile.fullname || a2.identity.profile.fullName))
+            || (a2.identity.space && a2.identity.space.displayName) || '';
+          return n1.localeCompare(n2);
+        });
+      return owner ? [owner, ...others] : others;
+    },
+    displayedAttendees() {
+      return this.sortedAttendees.slice(0, this.displayedCount);
+    },
+    hasMore() {
+      return this.sortedAttendees.length > this.displayedCount;
+    },
+    searchOptions() {
+      return {
+        currentUser: '',
+        spaceURL: this.event
+          && this.event.calendar
+          && this.event.calendar.owner
+          && this.event.calendar.owner.remoteId,
+      };
+    },
+    participantSuggesterLabels() {
+      return {
+        searchPlaceholder: this.$t('agenda.searchPlaceholder'),
+        placeholder: this.$t('agenda.attendees.searchPlaceholder'),
+        noDataLabel: this.$t('agenda.noDataLabel'),
+      };
+    },
+    ignoredMembers() {
+      return this.event.attendees
+        ? this.event.attendees.map(a => `${a.identity.providerId}:${a.identity.remoteId}`)
+        : [];
+    },
+    disableAttendeeSuggester() {
+      return !this.event.calendar || !this.event.calendar.owner || !this.event.calendar.owner.remoteId;
+    },
+    suggesterStatus() {
+      return this.disableAttendeeSuggester ? this.$t('agenda.suggesterRequired.tooltip') : '';
+    },
+  },
+  watch: {
+    invitedAttendee(val) {
+      if (!val) {
+        this.$nextTick(this.$refs.invitedAttendeeAutoComplete.$refs.selectAutoComplete.deleteCurrentItem);
+        return;
+      }
+      if (!this.event.attendees) {
+        this.event.attendees = [];
+      }
+      const found = this.event.attendees.find(a =>
+        a.identity.remoteId === val.remoteId && a.identity.providerId === val.providerId
+      );
+      if (!found) {
+        this.event.attendees.push({
+          identity: this.$suggesterService.convertSuggesterItemToIdentity(val),
+          response: 'NEEDS_ACTION',
+        });
+      }
+      this.invitedAttendee = null;
+    },
+  },
+  methods: {
+    open() {
+      this.displayedCount = PAGE_SIZE;
+      this.showSuggester = false;
+      this.$refs.attendeesDrawer.open();
+    },
+    loadMore() {
+      this.displayedCount += PAGE_SIZE;
+    },
+    removeAttendee(attendee) {
+      if (!this.event || !this.event.attendees) {
+        return;
+      }
+      const index = this.event.attendees.findIndex(a =>
+        a.identity.remoteId === attendee.identity.remoteId
+        && a.identity.providerId === attendee.identity.providerId
+      );
+      if (index >= 0) {
+        this.event.attendees.splice(index, 1);
+      }
+    },
+    checkGuestInvitation(evt) {
+      const self = this;
+      $('form').on('focusout', function(event) {
+        setTimeout(function() {
+          if (!event.delegateTarget.contains(document.activeElement)) {
+            self.saveGuestEmail(event);
+          }
+        }, 1);
+      });
+      if (evt.key === 'Enter') {
+        evt.preventDefault();
+        this.saveGuestEmail(evt);
+      }
+      if (evt.keyCode === 32) {
+        this.saveGuestEmail(evt);
+      }
+    },
+    saveGuestEmail() {
+      const reg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,24}))$/;
+      const input = this.$refs?.invitedAttendeeAutoComplete?.searchTerm?.toLowerCase();
+      const words = input !== null ? input.split(' ') : '';
+      const email = words[words.length - 1];
+      if (reg.test(email)) {
+        this.event.attendees.push({
+          identity: {
+            id: `${email}`,
+            remoteId: email,
+            identityId: email,
+            providerId: 'GUEST_USER',
+            profile: {
+              fullName: email,
+              avatarUrl: '/portal/rest/v1/social/users/default-image/avatar',
+            },
+          },
+        });
+      }
+      this.$refs.invitedAttendeeAutoComplete.clear();
+    },
+  },
+};
+</script>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
@@ -4,29 +4,29 @@
     class="flex"
     flat
     @submit="$emit('next-step')">
-    <div class="d-flex flex-column flex-md-row">
-      <v-icon size="20" class="icon-default-color my-auto me-12 d-none d-md-inline">far fa-calendar</v-icon>
-      <input
-        id="eventTitle"
-        ref="eventTitle"
-        v-model="event.summary"
-        :placeholder="$t('agenda.eventTitle')"
-        type="text"
-        name="title"
-        class="ignore-vuetify-classes my-3"
-        required
-        @change="resetCustomValidity">
-      <label class="mt-5 ms-4 me-4 text-subtitle-1 font-weight-bold d-none d-md-inline">
-        {{ $t('agenda.label.in') }}
-      </label>
-      <agenda-event-form-calendar-owner
-        ref="calendarOwner"
-        :event="event"
-        :current-space="currentSpace"
-        @initialized="$emit('initialized')" />
-    </div>
     <div class="d-flex flex-column flex-md-row mt-1 event-form-body">
       <div class="d-flex flex-column flex-grow-1 event-form-body-left">
+        <div class="d-flex flex-row">
+          <v-icon size="20" class="icon-default-color my-auto me-12 d-none d-md-inline">far fa-calendar</v-icon>
+          <input
+            id="eventTitle"
+            ref="eventTitle"
+            v-model="event.summary"
+            :placeholder="$t('agenda.eventTitle')"
+            type="text"
+            name="title"
+            class="ignore-vuetify-classes my-3"
+            required
+            @change="resetCustomValidity">
+          <label class="mt-5 ms-4 me-4 text-subtitle-1 font-weight-bold d-none d-md-inline">
+            {{ $t('agenda.label.in') }}
+          </label>
+          <agenda-event-form-calendar-owner
+            ref="calendarOwner"
+            :event="event"
+            :current-space="currentSpace"
+            @initialized="$emit('initialized')" />
+        </div>
         <div v-if="displayTimeInForm && eventDateOption" class="d-flex flex-row">
           <v-icon size="20" class="icon-default-color mb-auto pt-6 me-11">fas fa-clock</v-icon>
           <agenda-event-form-date-pickers
@@ -84,9 +84,9 @@
       <div class="d-none d-md-flex flex-column mx-5 event-form-body-divider ">
         <v-divider vertical />
       </div>
-      <div class="d-flex flex-column flex-grow-1 event-form-body-right">
+      <div class="d-flex flex-column flex-shrink-0 event-form-body-right">
         <div class="d-flex flex-row">
-          <v-flex class="flex-grow-0 me-2 mt-1">
+          <v-flex class="flex-grow-0 me-2 mt-2">
             <v-icon size="20" class="icon-default-color m-auto">fas fa-users</v-icon>
           </v-flex>
           <agenda-event-form-attendees

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventAttendees.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventAttendees.vue
@@ -1,17 +1,67 @@
 <template>
-  <div>
-    <div class="event-attendees-responses align-center d-flex">
-      <i class="uiIconGroup darkGreyIcon uiIcon32x32 pe-5"></i>
-      <span>{{ attendeesResponsesTitle }}</span>
+  <div class="d-flex align-center full-width">
+    <v-icon size="20" class="icon-default-color me-2 flex-shrink-0">fas fa-users</v-icon>
+    <div class="d-flex align-center ms-7 flex-grow-1 attendee-status-badges">
+      <v-tooltip v-if="acceptedResponsesCount" bottom>
+        <template #activator="{ on }">
+          <v-badge
+            :content="acceptedResponsesCount"
+            :value="acceptedResponsesCount"
+            color="#F8B121"
+            offset-x="9"
+            offset-y="8"
+            class="me-9">
+            <v-btn icon x-small v-on="on" @click="openDrawer">
+              <v-icon size="20" color="success">fas fa-check-circle</v-icon>
+            </v-btn>
+          </v-badge>
+        </template>
+        <span>{{ $t('agenda.accepted') }}: {{ acceptedResponsesCount }}</span>
+      </v-tooltip>
+      <v-tooltip v-if="needsActionResponsesCount" bottom>
+        <template #activator="{ on }">
+          <v-badge
+            :content="needsActionResponsesCount"
+            :value="needsActionResponsesCount"
+            color="#F8B121"
+            offset-x="9"
+            offset-y="8"
+            class="me-9">
+            <v-btn icon x-small v-on="on" @click="openDrawer">
+              <v-icon size="20" color="blue">fas fa-question-circle</v-icon>
+            </v-btn>
+          </v-badge>
+        </template>
+        <span>{{ $t('agenda.needs_action') }}: {{ needsActionResponsesCount }}</span>
+      </v-tooltip>
+      <v-tooltip v-if="refusedResponsesCount" bottom>
+        <template #activator="{ on }">
+          <v-badge
+            :content="refusedResponsesCount"
+            :value="refusedResponsesCount"
+            color="#F8B121"
+            offset-x="9"
+            offset-y="8"
+            class="me-9">
+            <v-btn icon x-small v-on="on" @click="openDrawer">
+              <v-icon size="20" color="error">fas fa-times-circle</v-icon>
+            </v-btn>
+          </v-badge>
+        </template>
+        <span>{{ $t('agenda.declined') }}: {{ refusedResponsesCount }}</span>
+      </v-tooltip>
     </div>
-    <div class="event-attendees mt-2 flex-column full-width">
-      <agenda-event-attendee-item
-        v-for="attendee in displayedAttendees"
-        :key="attendee"
-        :attendee="attendee"
-        :creator="event.creator"
-        class="mb-4" />
-    </div>
+    <agenda-event-attendees-avatars
+      v-if="displayedAttendees.length"
+      :attendees="displayedAttendees"
+      :max="3"
+      :size="32"
+      @open="openDrawer" />
+    <agenda-event-form-attendees-drawer
+      ref="attendeesDrawer"
+      :event="event"
+      :editable="canEdit"
+      @closed="saveAttendeesIfEditable" />
   </div>
 </template>
 
@@ -24,6 +74,9 @@ export default {
     },
   },
   computed: {
+    canEdit() {
+      return !!(this.event && this.event.acl && this.event.acl.canEdit);
+    },
     attendees() {
       return this.event && this.event.attendees || [];
     },
@@ -93,16 +146,40 @@ export default {
       ];
       return displayedAttendees;
     },
-    attendeesResponsesTitle() {
-      return this.$t('agenda.attendeesResponsesOverview', {
-        0: this.acceptedResponsesCount,
-        1: this.refusedResponsesCount,
-        2: this.needsActionResponsesCount,
-        3: this.tentativeResponsesCount,
+    visibleIdentities() {
+      return this.displayedAttendees.slice(0, 3).map(a => {
+        const identity = a.identity;
+        const profile = identity.profile || identity.space || {};
+        return {
+          ...identity,
+          username: identity.remoteId,
+          fullname: profile.fullname || profile.fullName || profile.displayName || identity.remoteId,
+          avatar: profile.avatar || profile.avatarUrl,
+        };
       });
     },
   },
+  data() {
+    return {
+      attendeesSnapshot: null,
+    };
+  },
   methods: {
+    openDrawer() {
+      this.attendeesSnapshot = (this.event && this.event.attendees || [])
+        .map(a => a.identity.remoteId).sort().join(',');
+      this.$refs.attendeesDrawer.open();
+    },
+    saveAttendeesIfEditable() {
+      if (!this.canEdit || !this.event) {
+        return;
+      }
+      const current = (this.event.attendees || [])
+        .map(a => a.identity.remoteId).sort().join(',');
+      if (current !== this.attendeesSnapshot) {
+        this.$eventService.updateEvent(this.event);
+      }
+    },
     sortAttendees(attendee1, attendee2) {
       const displayName1 = (attendee1.identity.profile && attendee1.identity.profile.fullname)
         || (attendee1.identity.space && attendee1.identity.space.displayName) || '';

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/initComponents.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/initComponents.js
@@ -40,6 +40,8 @@ import AgendaEventFormAttendees from './components/event/form/AgendaEventFormAtt
 import AgendaEventFormAttendeeItem from './components/event/form/AgendaEventFormAttendeeItem.vue';
 import AgendaEventFormCalendarOwner from './components/event/form/AgendaEventFormCalendarOwner.vue';
 import AgendaEventFormConference from './components/event/form/AgendaEventFormConference.vue';
+import AgendaEventFormAttendeesDrawer from './components/event/form/AgendaEventFormAttendeesDrawer.vue';
+import AgendaEventAttendeesAvatars from './components/event/common/AgendaEventAttendeesAvatars.vue';
 
 import AgendaEventDatePollDetails from './components/event/date-poll/AgendaEventDatePollDetails.vue';
 import AgendaEventDatePollDetailsMobile from './components/event/date-poll/mobile/AgendaEventDatePollDetailsMobile.vue';
@@ -157,6 +159,9 @@ const components = {
   'agenda-connector-contemporary-events': AgendaConnectorContemporaryEvents,
   'agenda-connector-remote-event-item': AgendaConnectorRemoteEventItem,
   'agenda-time-zone-select-box': AgendaTimeZoneSelectBox,
+  'agenda-event-form-attendees-drawer': AgendaEventFormAttendeesDrawer,
+  'agenda-event-attendees-avatars': AgendaEventAttendeesAvatars,
+  
 };
 
 for (const key in components) {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/content-publication-extensions/components/ContentEventDisplayReminder.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-extensions/content-publication-extensions/components/ContentEventDisplayReminder.vue
@@ -16,493 +16,131 @@
 -->
 
 <template>
-  <div>
-    <v-card
-      v-if="event"
-      class="pa-5 white border-box-sizing border-radius box-shadow"
-      :class="{
-        'full-width': !mdAndUp,
-        'ms-5': mdAndUp
-      }"
-      :width="mdAndUp && 330"
-      outlined>
-      <template v-if="loading">
-        <v-skeleton-loader type="heading" class="mb-3" />
-        <v-skeleton-loader type="text" class="mb-2" />
-        <v-skeleton-loader type="text" class="mb-2" />
-        <v-skeleton-loader type="text" class="mb-2" />
-      </template>
-      <template v-else-if="event">
-        <div class="d-flex align-center justify-space-between mb-3">
-          <span class="text-header text-header-color font-weight-medium">
-            {{ $t('contentEvent.reminder.title.label') }}
-          </span>
-          <v-btn
-            min-width="36"
-            class="btn btn-primary"
-            :href="eventUrl">
-            {{ $t('contentEvent.reminder.replay.label') }}
-          </v-btn>
-        </div>
-        <div
-          :class="{
-            'd-flex gap-2 justify-space-between': !mdAndUp && !smAndDown
-          }">
-          <div class="mb-3 flex-grow-1 flex-basis-0 overflow-hidden">
-            <div class="text-color text-font-size font-weight-bold mb-5">
-              {{ $t('contentEvent.reminder.highlights.label') }}
-            </div>
-            <div class="d-flex align-center mb-3">
-              <v-sheet
-                class="me-4 flex-shrink-0 d-flex align-center justify-center"
-                width="26">
-                <v-icon
-                  size="20"
-                  class="mx-auto icon-default-color">
-                  far fa-clock
-                </v-icon>
-              </v-sheet>
-              <span>{{ duration }}</span>
-            </div>
-            <div
-              v-if="hasRecurrence"
-              class="d-flex mb-3">
-              <v-sheet
-                class="me-4 d-flex flex-shrink-0 align-center justify-center"
-                width="26">
-                <v-icon
-                  size="20"
-                  class="mx-auto icon-default-color">
-                  fas fa-sync-alt
-                </v-icon>
-              </v-sheet>
-              <agenda-event-recurrence :event="event" />
-            </div>
-            <div v-if="locationHighlight" class="d-flex align-center">
-              <v-sheet
-                class="me-4 d-flex flex-shrink-0 align-center justify-center"
-                width="26">
-                <v-icon
-                  :size="20"
-                  class="mx-auto icon-default-color">
-                  fas fa-map-marker-alt
-                </v-icon>
-              </v-sheet>
-              <span>{{ locationHighlight }}</span>
-            </div>
-          </div>
-          <div class="flex-grow-1 flex-basis-0 overflow-hidden">
-            <div class="text-color text-font-size font-weight-bold mb-5">
-              {{ $t('contentEvent.reminder.Details.label') }}
-            </div>
-            <div class="d-flex align-center mb-3">
-              <v-sheet
-                class="me-4 flex-shrink-0 d-flex align-center justify-center"
-                width="26">
-                <v-icon
-                  size="20"
-                  class="max-auto icon-default-color">
-                  far fa-calendar-alt
-                </v-icon>
-              </v-sheet>
-              <div class="d-flex flex-column align-start">
-                <template v-if="isSameDay">
-                  <div class="d-flex flex-wrap align-center gap-1">
-                    <date-format
-                      class="flex-shrink-0"
-                      :value="eventStart"
-                      :format="fullDateFormat" />
-                    <template v-if="!isAllDayEvent">
-                      <span class="flex-shrink-0">·</span>
-                      <date-format
-                        class="flex-shrink-0"
-                        :value="eventStart"
-                        :format="timeFormat" />
-                    </template>
-                  </div>
-                </template>
-                <template v-else>
-                  <div class="d-flex flex-wrap align-center gap-1">
-                    <span class="flex-shrink-0">{{ $t('contentEvent.date.from.label') }}</span>
-                    <date-format
-                      class="flex-shrink-0"
-                      :value="eventStart"
-                      :format="fullDateFormat" />
-                  </div>
-                  <date-format
-                    v-if="!isAllDayEvent"
-                    class="flex-shrink-0"
-                    :value="eventStart"
-                    :format="timeFormat" />
-                </template>
-              </div>
-            </div>
-            <div v-if="!isSameDay" class="d-flex align-center mb-3">
-              <v-sheet
-                class="me-4 flex-shrink-0 d-flex align-center justify-center"
-                width="26">
-                <v-icon
-                  size="20"
-                  class="max-auto icon-default-color">
-                  far fa-calendar-alt
-                </v-icon>
-              </v-sheet>
-              <div class="d-flex flex-column align-start">
-                <div class="d-flex flex-wrap align-center gap-1">
-                  <span class="flex-shrink-0">{{ $t('contentEvent.date.to.label') }}</span>
-                  <date-format
-                    class="flex-shrink-0"
-                    :value="eventEnd"
-                    :format="fullDateFormat" />
-                </div>
-                <date-format
-                  v-if="!isAllDayEvent"
-                  class="flex-shrink-0"
-                  :value="eventEnd"
-                  :format="timeFormat" />
-              </div>
-            </div>
-            <div
-              v-if="eventLocation"
-              class="d-flex align-center mb-3">
-              <v-sheet
-                class="me-4 d-flex flex-shrink-0 align-center justify-center"
-                width="26">
-                <v-icon
-                  size="20"
-                  class="mx-auto icon-default-color">
-                  fas fa-map-marker-alt
-                </v-icon>
-              </v-sheet>
-              <span class="text-truncate no-min-width">
-                {{ eventLocation }}
-              </span>
-              <v-spacer />
-              <v-btn
-                v-if="activeMapProvider"
-                :href="mapsUrl"
-                :aria-label="$t('contentEvent.reminder.location.aria.label')"
-                :title="$t('contentEvent.reminder.location.aria.label')"
-                target="_blank"
-                width="28"
-                min-width="28"
-                height="28"
-                class="ms-2"
-                icon>
-                <v-icon
-                  size="20"
-                  class="icon-default-color">
-                  fas fa-directions
-                </v-icon>
-              </v-btn>
-            </div>
-            <div
-              v-if="webConferenceLink"
-              class="d-flex align-center">
-              <v-sheet
-                class="me-4 d-flex flex-shrink-0 align-center justify-center"
-                width="26">
-                <v-icon
-                  size="20"
-                  class="mx-auto icon-default-color">
-                  fas fa-video
-                </v-icon>
-              </v-sheet>
-              <v-btn
-                :href="webConferenceLink"
-                :aria-label="$t('contentEvent.reminder.meeting.aria.label')"
-                height="24"
-                class="text-none btn btn-primary border-radius-16 px-3"
-                target="_blank"
-                x-small
-                outlined>
-                {{ $t('contentEvent.reminder.join.label') }}
-              </v-btn>
-            </div>
-            <div
-              v-if="showMap"
-              class="mt-3 position-relative">
-              <v-skeleton-loader
-                v-if="geocoding || !mapLoaded"
-                type="image"
-                height="200"
-                class="border-radius" />
-              <iframe
-                v-if="mapEmbedUrl"
-                :src="mapEmbedUrl"
-                :title="$t('contentEvent.location.label')"
-                :class="mapLoaded ? '' : 'position-absolute t-0'"
-                class="border-radius no-border"
-                width="100%"
-                height="200"
-                loading="lazy"
-                @load="mapLoaded = true"></iframe>
-            </div>
-          </div>
-        </div>
-      </template>
-    </v-card>
-    <exo-confirm-dialog
-      ref="eventDeleteConfirmDialog"
-      :message="$t('contentEvent.event.deletion.from.content.message')"
-      :title="$t('contentEvent.event.deletion.title')"
-      :ok-label="$t('contentEvent.confirm.label')"
-      :cancel-label="$t('contentEvent.cancel.label')"
-      @ok="confirmEventDeletion"
-      @closed="cancelEventDeletion" />
+  <div class="d-flex align-center flex-grow-1 flex-wrap">
+    <v-icon size="16" class="icon-default-color me-2">fas fa-users</v-icon>
+    <span class="body-2 me-2">{{ $t('agenda.participants') }}</span>
+    <v-btn
+      :title="$t('agenda.addParticipants')"
+      icon
+      x-small
+      @click="openDrawer">
+      <v-icon size="16" class="icon-default-color">fas fa-plus</v-icon>
+    </v-btn>
+    <div
+      v-if="sortedAttendees.length"
+      class="d-flex align-center ms-2 agenda-attendees-strip"
+      @mouseenter="showSeeMore = true"
+      @mouseleave="showSeeMore = false"
+      @focusin="showSeeMore = true"
+      @focusout="showSeeMore = false">
+      <v-tooltip
+        v-for="attendee in visibleAttendees"
+        :key="attendee.identity.id"
+        bottom>
+        <template #activator="{ on }">
+          <v-avatar
+            :tile="attendee.identity.providerId === 'space'"
+            size="26"
+            class="me-1"
+            style="cursor:pointer"
+            v-on="on"
+            @click="openDrawer">
+            <v-img :src="getAvatarUrl(attendee)" :lazy-src="defaultAvatarUrl" />
+          </v-avatar>
+        </template>
+        <span>{{ getDisplayName(attendee) }}</span>
+      </v-tooltip>
+      <v-btn
+        v-if="overflowCount > 0 && !showSeeMore"
+        x-small
+        text
+        class="caption px-1 min-width-unset"
+        @click="openDrawer">
+        +{{ overflowCount }}
+      </v-btn>
+      <v-btn
+        v-if="showSeeMore"
+        x-small
+        text
+        class="caption px-1"
+        @click="openDrawer">
+        {{ $t('agenda.timeline.seeMore') }}
+      </v-btn>
+    </div>
+    <agenda-event-form-attendees-drawer
+      ref="attendeesDrawer"
+      :event="event"
+      @initialized="$emit('initialized')" />
   </div>
 </template>
 
 <script>
-
 export default {
+  props: {
+    event: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
   data() {
     return {
-      expand: 'attendees,reminders,recurrence,conferences',
-      event: null,
-      mapLoaded: false,
-      loading: false,
-      eventToDelete: false,
-      coords: null,
-      bbox: null,
-      geocoding: true,
-      geocodingFailed: false,
-      geocodeResult: null,
-      activeMapProvider: null,
+      showSeeMore: false,
+      maxVisible: 3,
     };
   },
-  props: {
-    eventId: {
-      type: Object,
-      default: null
-    },
-    customBreakPointThreshold: {
-      type: Number,
-      default: 0
-    }
-  },
-  inject: ['registerDeleteInterceptor', 'unregisterDeleteInterceptor'],
   computed: {
-    isSameDay() {
-      if (!this.eventStart || !this.eventEnd) {
-        return true;
-      }
-      const start = new Date(this.eventStart);
-      const end = new Date(this.eventEnd);
-      return start.getFullYear() === end.getFullYear()
-          && start.getMonth() === end.getMonth()
-          && start.getDate() === end.getDate();
+    defaultAvatarUrl() {
+      return '/portal/rest/v1/social/users/default-image/avatar';
     },
-    showMap() {
-      return !!this.activeMapProvider
-          && !!this.eventLocation
-          && this.mdAndUp
-          && this.showLocationMap
-          && !this.geocodingFailed
-          && !this.geocoding;
+    sortedAttendees() {
+      if (!this.event.attendees) { return []; }
+      const creatorId = this.event.creator && this.event.creator.id;
+      const ownerId = creatorId || eXo.env.portal.userIdentityId;
+      const owner = this.event.attendees.find(a => Number(a.identity.id) === Number(ownerId));
+      const others = this.event.attendees
+        .filter(a => a !== owner)
+        .sort((a, b) => (this.getDisplayName(a) || '').localeCompare(this.getDisplayName(b) || ''));
+      return owner ? [owner, ...others] : others;
     },
-    showLocationMap() {
-      return this.event?.parameters?.showLocationMap === 'true';
+    visibleAttendees() {
+      return this.sortedAttendees.slice(0, this.maxVisible);
     },
-    mdAndUp () {
-      return this.$vuetify.breakpoint.width >= this.$vuetify.breakpoint.thresholds.md - this.customBreakPointThreshold;
+    overflowCount() {
+      return Math.max(0, this.sortedAttendees.length - this.maxVisible);
     },
-    smAndDown () {
-      return this.$vuetify.breakpoint.width <= this.$vuetify.breakpoint.thresholds.sm + this.customBreakPointThreshold;
-    },
-    mapEmbedUrl() {
-      if (!this.activeMapProvider || !this.geocodeResult) {
-        return null;
-      }
-      return this.activeMapProvider.mapEmbedUrl(this.geocodeResult);
-    },
-    mapsUrl() {
-      if (!this.activeMapProvider) {
-        return null;
-      }
-      return this.activeMapProvider.mapsUrl(this.geocodeResult || { location: this.eventLocation });
-    },
-    eventStart() {
-      return this.event?.start;
-    },
-    eventEnd() {
-      return this.event?.end;
-    },
-    tz() {
-      return this.event?.timeZoneId || 'UTC';
-    },
-    fullDateFormat() {
-      return {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        timeZone: this.tz,
-      };
-    },
-    timeFormat() {
-      return {
-        hour: '2-digit',
-        minute: '2-digit',
-        timeZoneName: 'short',
-        timeZone: this.tz,
-      };
-    },
-    webConferenceLink() {
-      return this.event?.conferences?.[0]?.url;
-    },
-    eventLocation() {
-      return this.event?.location;
-    },
-    isAllDayEvent() {
-      return this.event?.allDay;
-    },
-    duration() {
-      if (this.isAllDayEvent) {
-        return this.$t('agenda.allDay');
-      }
-      const ms = new Date(this.eventEnd) - new Date(this.eventStart);
-      const totalMinutes = Math.floor(ms / 60000);
-      const d = Math.floor(totalMinutes / 1440);
-      const h = Math.floor((totalMinutes % 1440) / 60);
-      const m = totalMinutes % 60;
-      const parts = [];
-      if (d) {
-        parts.push(`${d} ${this.$t(`contentEvent.reminder.day${d > 1 ? 's' : ''}.label`)}`);
-      }
-      if (h) {
-        parts.push(`${h} ${this.$t(`contentEvent.reminder.hour${h > 1 ? 's' : ''}.label`)}`);
-      }
-      if (m) {
-        parts.push(`${m} ${this.$t('contentEvent.reminder.minutes.label')}`);
-      }
-      return parts.join(' ');
-    },
-    hasRecurrence() {
-      return  this.event?.recurrence;
-    },
-    locationHighlight() {
-      const hasConference = !!this.webConferenceLink;
-      const hasLocation = !!this.eventLocation;
-      if (hasLocation && hasConference) {
-        return `${this.$t('contentEvent.reminder.online.label')} · ${this.$t('contentEvent.reminder.inperson.label')}`;
-      }
-      if (hasConference) {
-        return this.$t('contentEvent.reminder.online.label');
-      }
-      if (hasLocation) {
-        return this.$t('contentEvent.reminder.inperson.label');
-      }
-      return null;
-    },
-    eventUrl() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda?eventId=${this.event?.id}`;
-    }
-  },
-  watch: {
-    eventLocation() {
-      this.mapLoaded = false;
-      this.coords = null;
-      this.geocodeResult = null;
-      this.geocodingFailed = false;
-      if (this.eventLocation) {
-        this.geocode(this.eventLocation);
-      }
-    },
-    mapEmbedUrl(newVal) {
-      if (newVal) {
-        this.mapLoaded = false;
-      }
-    }
-  },
-  async created() {
-    await this.loadActiveMapProvider();
-    this.init();
-    this.$root.$on('confirm-news-deletion', this.deleteEvent);
-
-    document.addEventListener('content-event-updated', this.init);
-    document.addEventListener('content-event-removed', this.eventRemoved);
-  },
-  beforeDestroy() {
-    this.$root.$off('confirm-news-deletion', this.deleteEvent);
-
-    this.unregisterDeleteInterceptor(this.preDeleteInterceptor);
-    document.removeEventListener('content-event-updated', this.init);
-    document.removeEventListener('content-event-removed', this.eventRemoved);
   },
   mounted() {
-    this.registerDeleteInterceptor(this.preDeleteInterceptor.bind(this));
+    this.$userService.getUser(eXo.env.portal.userName).then(user => {
+      this.$root.$emit('current-user', user);
+      if (!this.event.id && !this.event.occurrence && (!this.event.attendees || !this.event.attendees.length)) {
+        this.event.attendees = [{
+          identity: {
+            id: eXo.env.portal.userIdentityId,
+            providerId: 'organization',
+            remoteId: eXo.env.portal.userName,
+            profile: {
+              avatar: user.avatar,
+              fullname: user.fullname,
+              external: user.external === 'true',
+            },
+          },
+        }];
+      }
+      this.$emit('initialized');
+    });
   },
   methods: {
-    async loadActiveMapProvider() {
-      const settings = await this.$settingsService.getUserSettings();
-      const savedProviderId = settings?.embedMapProvider;
-
-      const providers = extensionRegistry.loadExtensions('EmbedMapProviders', 'embedMapProviders');
-      const sorted = providers
-        .filter(p => p.enabled())
-        .sort((a, b) => a.rank - b.rank);
-
-      this.activeMapProvider = (savedProviderId
-              && sorted.find(p => p.id === savedProviderId)) || null;
+    openDrawer() {
+      this.$refs.attendeesDrawer.open();
     },
-    async geocode(location) {
-      if (!this.activeMapProvider?.geocode) {
-        return;
-      }
-      this.geocoding = true;
-      this.geocodingFailed = false;
-      try {
-        const result = await this.activeMapProvider.geocode(location, eXo.env.portal.language);
-        if (result) {
-          this.geocodeResult = result;
-        } else {
-          this.geocodingFailed = true;
-        }
-      } finally {
-        this.geocoding = false;
-      }
+    getAvatarUrl(attendee) {
+      const profile = attendee.identity && (attendee.identity.profile || attendee.identity.space);
+      return profile && (profile.avatarUrl || profile.avatar) || this.defaultAvatarUrl;
     },
-    async deleteEvent() {
-      if (this.eventToDelete) {
-        await this.$eventService.deleteEvent(this.eventId);
-      }
+    getDisplayName(attendee) {
+      const profile = attendee.identity && (attendee.identity.profile || attendee.identity.space);
+      return profile && (profile.displayName || profile.fullname || profile.fullName) || attendee.identity.remoteId;
     },
-    preDeleteInterceptor({ content }) {
-      const eventId = content?.parameters?.eventId;
-      if (!eventId) {
-        return true;
-      }
-      return new Promise((resolve) => {
-        this._preDeleteResolve = resolve;
-        this.$refs.eventDeleteConfirmDialog.open();
-      });
-    },
-    confirmEventDeletion() {
-      this.eventToDelete = true;
-      this._preDeleteResolve?.(true);
-    },
-    cancelEventDeletion() {
-      this.eventToDelete = false;
-      this._preDeleteResolve?.(true);
-    },
-    eventRemoved() {
-      this.event = null;
-    },
-    async init() {
-      if (!this.eventId) {
-        return;
-      }
-      this.loading = true;
-      this.event = null;
-      try {
-        this.event = await this.$eventService.getEventById(this.eventId, this.expand);
-        if (this.eventLocation) {
-          this.geocode(this.eventLocation);
-        }
-      } finally {
-        this.loading = false;
-      }
-    }
-  }
+  },
 };
 </script>


### PR DESCRIPTION
Allow participants to be added or removed directly from both view and edit modes. A new shared avatar strip component handles display consistently across both modes, with space avatars rendered as squares and a See more hover action to open the full participants drawer.