### PR TITLE
feat: Review event form icons - EXO-88084

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/view/AgendaEventsDetailsBody.vue
@@ -96,18 +96,14 @@
                 @click="openConferenceLink">
                 {{ $t('agenda.button.joinMeeting') }}
               </v-btn>
-              <v-tooltip bottom>
-                <template #activator="{ on }">
-                  <v-btn
-                    icon
-                    small
-                    v-on="on"
-                    @click="copyConferenceLink">
-                    <v-icon size="16">fas fa-copy</v-icon>
-                  </v-btn>
-                </template>
-                <span>{{ $t('agenda.tooltip.meeting.copyLink') }}</span>
-              </v-tooltip>
+              <v-btn
+                :title="$t('agenda.tooltip.meeting.copyLink')"
+                icon
+                small
+                v-on="on"
+                @click="copyConferenceLink">
+                <v-icon size="16">fas fa-copy</v-icon>
+              </v-btn>
             </div>
             <span class="text-subtitle text-truncate mt-1">{{ eventConferenceUrl }}</span>
           </div>


### PR DESCRIPTION
Show the web conference link directly in the event detail view with a Join the meeting button opening the link in a new tab, a copy icon to copy the link to the clipboard with a success notification, and the link URL displayed below for reference.