### PR TITLE
fix: Startup latency on   timezone update from tzurl.org without Internet access - EXO-88258

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/util/Utils.java
@@ -69,7 +69,9 @@ public class Utils {
 
   private static final Log              LOG                            = ExoLogger.getLogger(Utils.class);
 
-  private static final TimeZoneRegistry ICAL4J_TIME_ZONE_REGISTRY      = TimeZoneRegistryFactory.getInstance().createRegistry();
+  private static class ICal4jTimeZoneRegistryHolder {
+    private static final TimeZoneRegistry INSTANCE = TimeZoneRegistryFactory.getInstance().createRegistry();
+  }
 
   public static final String EVENT_METADATA_NAME                       = "agendaEvent";
 
@@ -517,7 +519,7 @@ public class Utils {
   }
 
   public static net.fortuna.ical4j.model.TimeZone getICalTimeZone(ZoneId zoneId) {
-    return ICAL4J_TIME_ZONE_REGISTRY.getTimeZone(zoneId.getId());
+    return ICal4jTimeZoneRegistryHolder.INSTANCE.getTimeZone(zoneId.getId());
   }
 
   public static ZonedDateTime toDateTime(String dateTimeString, ZoneId userTimeZone) {

--- a/agenda-services/src/main/resources/ical4j.properties
+++ b/agenda-services/src/main/resources/ical4j.properties
@@ -1,1 +1,2 @@
 net.fortuna.ical4j.timezone.cache.impl=net.fortuna.ical4j.util.MapTimeZoneCache
+net.fortuna.ical4j.timezone.update.enabled=false


### PR DESCRIPTION
Prior to this, server startup (and reminder computing for recurrent events) could be significantly slowed down when the server has no internet access. Every timezone resolution done via Utils#getICalTimeZone() triggered a network call to www.tzurl.org, which had to time out before failing.

This is caused by ical4j's TimeZoneUpdater being enabled by default, combined with the shared TimeZoneRegistry being built eagerly as a static field of Utils, loaded as soon as the class is referenced.

This commit fixes the problem by disabling ical4j's online timezone update checks (net.fortuna.ical4j.timezone.update.enabled=false) and by lazily initializing the TimeZoneRegistry on first use instead of at class-loading time.