### PR TITLE
fix: mark AgendaTimeline portlet content as editable - exo-88432

### DIFF
--- a/agenda-api/pom.xml
+++ b/agenda-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-api</artifactId>
   <name>eXo Agenda - API</name>

--- a/agenda-packaging/pom.xml
+++ b/agenda-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-packaging</artifactId>
   <packaging>pom</packaging>

--- a/agenda-services/pom.xml
+++ b/agenda-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-services</artifactId>
   <name>eXo Agenda - Services</name>

--- a/agenda-webapps/pom.xml
+++ b/agenda-webapps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.agenda</groupId>
     <artifactId>agenda-parent</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-ai-contribution-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-webapps</artifactId>
   <packaging>war</packaging>

--- a/agenda-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/agenda-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -33,6 +33,10 @@
     <name>portlet-view-dispatched-file-path</name>
     <value>/WEB-INF/jsp/agendaTimeline.jsp</value>
     </init-param>
+    <init-param>
+    <name>layout-content-editable</name>
+    <value>true</value>
+    </init-param>
     <supports>
     <mime-type>text/html</mime-type>
     </supports>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.agenda</groupId>
   <artifactId>agenda-parent</artifactId>
-  <version>7.3.x-SNAPSHOT</version>
+  <version>7.3.x-ai-contribution-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Agenda - Parent POM</name>
   <description>eXo Agenda Addon</description>
@@ -27,7 +27,7 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.commons-exo.version>7.3.x-SNAPSHOT</org.exoplatform.commons-exo.version>
+    <org.exoplatform.commons-exo.version>7.3.x-ai-contribution-SNAPSHOT</org.exoplatform.commons-exo.version>
 
     <!-- ical4j dependencies -->
     <org.mnode.ical4j.version>3.2.19</org.mnode.ical4j.version>


### PR DESCRIPTION
Enables the removal-confirmation dialog in the page builder for the Agenda Timeline content block, consistent with other admin-editable blocks.