### PR TITLE
feat: Agenda scheduling MCP tools (date polls, free/busy, recurrence, conflict-aware) + relocation to open add-on - EXO-88461

### DIFF
--- a/agenda-services/pom.xml
+++ b/agenda-services/pom.xml
@@ -79,10 +79,26 @@
       <artifactId>pwa-service</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- MCP Server API (used by the agenda MCP tools exposed to the AI agent) -->
+    <dependency>
+      <groupId>io.meeds.mcp-server</groupId>
+      <artifactId>mcp-server-tools</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>agenda-services</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <!-- Required so MCP tool method parameter names are retained and bound by name -->
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
@@ -20,12 +20,16 @@ import static io.meeds.mcp.server.tool.util.SpaceToolUtils.toSpaceModel;
 import static io.meeds.mcp.server.tool.util.UserToolUtils.toUserModel;
 import static io.meeds.mcp.server.util.McpToolUtils.formatDate;
 
+import java.time.Duration;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -39,26 +43,42 @@ import org.springframework.stereotype.Service;
 
 import org.exoplatform.agenda.constant.EventAttendeeResponse;
 import org.exoplatform.agenda.constant.EventAvailability;
+import org.exoplatform.agenda.constant.EventRecurrenceFrequency;
+import org.exoplatform.agenda.constant.EventRecurrenceType;
 import org.exoplatform.agenda.constant.EventStatus;
+import org.exoplatform.agenda.constant.ReminderPeriodType;
 import org.exoplatform.agenda.exception.AgendaException;
 import org.exoplatform.agenda.mcp.model.AgendaEventAttendeeModel;
 import org.exoplatform.agenda.mcp.model.AgendaEventCollectionModel;
 import org.exoplatform.agenda.mcp.model.AgendaEventModel;
+import org.exoplatform.agenda.mcp.model.AttendeeConflictModel;
+import org.exoplatform.agenda.mcp.model.AvailabilityModel;
+import org.exoplatform.agenda.mcp.model.ConferenceModel;
+import org.exoplatform.agenda.mcp.model.ConflictsModel;
+import org.exoplatform.agenda.mcp.model.DatePollModel;
+import org.exoplatform.agenda.mcp.model.DatePollOptionModel;
+import org.exoplatform.agenda.mcp.model.TimeBlockModel;
 import org.exoplatform.agenda.model.AgendaUserSettings;
 import org.exoplatform.agenda.model.Calendar;
 import org.exoplatform.agenda.model.Event;
 import org.exoplatform.agenda.model.EventAttendee;
 import org.exoplatform.agenda.model.EventAttendeeList;
 import org.exoplatform.agenda.model.EventConference;
+import org.exoplatform.agenda.model.EventDateOption;
 import org.exoplatform.agenda.model.EventFilter;
 import org.exoplatform.agenda.model.EventPermission;
+import org.exoplatform.agenda.model.EventRecurrence;
 import org.exoplatform.agenda.model.EventReminder;
 import org.exoplatform.agenda.model.EventReminderParameter;
+import org.exoplatform.agenda.model.EventSearchResult;
+import org.exoplatform.agenda.model.AgendaEventSearchFilter;
 import org.exoplatform.agenda.plugin.AgendaEventAclPlugin;
 import org.exoplatform.agenda.plugin.AgendaEventPermanentLinkPlugin;
 import org.exoplatform.agenda.service.AgendaCalendarService;
 import org.exoplatform.agenda.service.AgendaEventAttendeeService;
 import org.exoplatform.agenda.service.AgendaEventConferenceService;
+import org.exoplatform.agenda.service.AgendaEventDatePollService;
+import org.exoplatform.agenda.service.AgendaEventReminderService;
 import org.exoplatform.agenda.service.AgendaEventService;
 import org.exoplatform.agenda.service.AgendaUserSettingsService;
 import org.exoplatform.agenda.util.AgendaDateUtils;
@@ -109,6 +129,8 @@ public class AgendaEventMcpTool implements McpToolPlugin {
 
   private static final int                   MAX_LIMIT                            = 100;
 
+  private static final int                   BUSY_QUERY_LIMIT                     = 500;
+
   private final SpaceService                 spaceService;
 
   private final IdentityManager              identityManager;
@@ -120,6 +142,10 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   private final AgendaEventAttendeeService   agendaEventAttendeeService;
 
   private final AgendaEventConferenceService agendaEventConferenceService;
+
+  private final AgendaEventDatePollService   agendaEventDatePollService;
+
+  private final AgendaEventReminderService   agendaEventReminderService;
 
   private final AgendaUserSettingsService    agendaUserSettingsService;
 
@@ -138,6 +164,8 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                             AgendaEventService agendaEventService,
                             AgendaEventConferenceService agendaEventConferenceService,
                             AgendaEventAttendeeService agendaEventAttendeeService,
+                            AgendaEventDatePollService agendaEventDatePollService,
+                            AgendaEventReminderService agendaEventReminderService,
                             AgendaUserSettingsService agendaUserSettingsService,
                             UserPortalConfigService portalConfigService,
                             ProfilePropertyService profilePropertyService,
@@ -149,6 +177,8 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     this.agendaEventService = agendaEventService;
     this.agendaEventAttendeeService = agendaEventAttendeeService;
     this.agendaEventConferenceService = agendaEventConferenceService;
+    this.agendaEventDatePollService = agendaEventDatePollService;
+    this.agendaEventReminderService = agendaEventReminderService;
     this.agendaUserSettingsService = agendaUserSettingsService;
     this.agendaCalendarService = agendaCalendarService;
     this.profilePropertyService = profilePropertyService;
@@ -205,15 +235,22 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     return toAgendaEventModel(event);
   }
 
+  // Create an agenda event, optionally recurrent, with a server-side conflict report over its attendees.
+  // When fail_on_conflict is true and at least one attendee is busy/tentative in the window, creation is aborted.
   public AgendaEventModel createAgendaEvent(Long spaceId,
                                             String summary,
                                             String description,
                                             String location,
                                             String start,
                                             String end,
-                                            List<String> attendeeUsernames) throws IllegalAccessException,
-                                                                            ObjectNotFoundException,
-                                                                            AgendaException {
+                                            List<String> attendeeUsernames,
+                                            String recurrenceFrequency,
+                                            Integer recurrenceInterval,
+                                            String recurrenceUntil,
+                                            Integer recurrenceCount,
+                                            Boolean failOnConflict) throws IllegalAccessException,
+                                                                    ObjectNotFoundException,
+                                                                    AgendaException {
     if (spaceId == null || spaceId == 0) {
       throw new IllegalArgumentException(MSG_PARAMETER_SPACE_ID_MANDATORY);
     } else if (!userAcl.hasPermission(SpaceAclPlugin.OBJECT_TYPE,
@@ -225,6 +262,15 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     long userIdentityId = getCurrentUserIdentityId();
     ZonedDateTime startDate = toZonedDateTime(start);
     ZonedDateTime endDate = toZonedDateTime(end);
+    List<EventAttendee> attendees = toEventAttendees(attendeeUsernames, true);
+
+    // Compute the conflict report over the event window before writing anything
+    ConflictsModel conflicts = computeConflicts(attendees, startDate, endDate, userIdentityId);
+    if (Boolean.TRUE.equals(failOnConflict) && !conflicts.isAllAvailable()) {
+      throw new IllegalStateException("Event not created: %s attendee(s) have a conflict in the requested window"
+          .formatted(conflicts.getConflicts().size()));
+    }
+
     Event event = new Event(0l,
                             0l,
                             getSpaceCalendarId(spaceId),
@@ -242,23 +288,27 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                             false,
                             EventAvailability.DEFAULT,
                             EventStatus.CONFIRMED,
-                            null,
+                            buildRecurrence(recurrenceFrequency, recurrenceInterval, recurrenceUntil, recurrenceCount),
                             null,
                             new EventPermission(true, true),
                             true,
                             true);
     Event createdEvent = agendaEventService.createEvent(event,
-                                                        toEventAttendees(attendeeUsernames, true),
+                                                        attendees,
                                                         null,
                                                         getDefaultUserEventReminders(),
                                                         null,
                                                         null,
                                                         true,
                                                         userIdentityId);
-    return toAgendaEventModel(createdEvent);
+    AgendaEventModel model = toAgendaEventModel(createdEvent);
+    model.setConflicts(conflicts);
+    return model;
   }
 
-  public void declineAgendaEventInvitation(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
+  // Decline an event invitation; when occurrence_id is given, only that single occurrence (and upcoming ones) is declined.
+  public void declineAgendaEventInvitation(Long eventId, String occurrenceId) throws IllegalAccessException,
+                                                                              ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
       throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
     } else if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE,
@@ -266,11 +316,19 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                             getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
     }
-    agendaEventAttendeeService.sendEventResponse(eventId, getCurrentUserIdentityId(), EventAttendeeResponse.DECLINED);
+    if (StringUtils.isNotBlank(occurrenceId)) {
+      agendaEventAttendeeService.sendUpcomingEventResponse(eventId,
+                                                           toZonedDateTime(occurrenceId),
+                                                           getCurrentUserIdentityId(),
+                                                           EventAttendeeResponse.DECLINED);
+    } else {
+      agendaEventAttendeeService.sendEventResponse(eventId, getCurrentUserIdentityId(), EventAttendeeResponse.DECLINED);
+    }
   }
 
-  public void cancelAgendaEvent(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
-    declineAgendaEventInvitation(eventId);
+  // Cancel (decline) participation in an event; supports single-occurrence cancellation via occurrence_id.
+  public void cancelAgendaEvent(Long eventId, String occurrenceId) throws IllegalAccessException, ObjectNotFoundException {
+    declineAgendaEventInvitation(eventId, occurrenceId);
   }
 
   public void acceptAgendaEventInvitation(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
@@ -358,12 +416,21 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     return getAgendaEventById(eventId);
   }
 
+  // Update an agenda event (only provided fields change), optionally (re)setting recurrence, with a conflict report.
+  // When fail_on_conflict is true and an attendee is busy/tentative in the (new) window, the update is aborted.
   public AgendaEventModel updateAgendaEvent(Long eventId,
                                             String summary,
                                             String description,
                                             String location,
                                             String start,
-                                            String end) throws IllegalAccessException, ObjectNotFoundException, AgendaException {
+                                            String end,
+                                            String recurrenceFrequency,
+                                            Integer recurrenceInterval,
+                                            String recurrenceUntil,
+                                            Integer recurrenceCount,
+                                            Boolean failOnConflict) throws IllegalAccessException,
+                                                                    ObjectNotFoundException,
+                                                                    AgendaException {
     if (eventId == null || eventId == 0) {
       throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
     } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
@@ -371,28 +438,62 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                           getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
     }
-    Map<String, List<String>> fieldsToUpdate = new HashMap<>();
-    if (summary != null) {
-      fieldsToUpdate.put("summary", Collections.singletonList(summary));
+    long userIdentityId = getCurrentUserIdentityId();
+    Event existingEvent = agendaEventService.getEventById(eventId, TIMEZONE, userIdentityId);
+    if (existingEvent == null) {
+      throw new ObjectNotFoundException("Agenda Event with id %s not found".formatted(eventId));
     }
-    if (description != null) {
-      fieldsToUpdate.put("description", Collections.singletonList(description));
+    // Resolve the effective window (new values if provided, else the current event's) for the conflict report
+    ZonedDateTime startDate = start != null ? toZonedDateTime(start) : existingEvent.getStart();
+    ZonedDateTime endDate = end != null ? toZonedDateTime(end) : existingEvent.getEnd();
+    List<EventAttendee> attendees = getExistingEventAttendees(eventId);
+    ConflictsModel conflicts = computeConflicts(attendees, startDate, endDate, userIdentityId);
+    if (Boolean.TRUE.equals(failOnConflict) && !conflicts.isAllAvailable()) {
+      throw new IllegalStateException("Event not updated: %s attendee(s) have a conflict in the requested window"
+          .formatted(conflicts.getConflicts().size()));
     }
-    if (location != null) {
-      fieldsToUpdate.put("location", Collections.singletonList(location));
+
+    EventRecurrence recurrence = buildRecurrence(recurrenceFrequency, recurrenceInterval, recurrenceUntil, recurrenceCount);
+    if (recurrence != null) {
+      // Recurrence changes require a full-event update (updateEventFields doesn't support recurrence)
+      if (summary != null) {
+        existingEvent.setSummary(summary);
+      }
+      if (description != null) {
+        existingEvent.setDescription(description);
+      }
+      if (location != null) {
+        existingEvent.setLocation(location);
+      }
+      existingEvent.setStart(startDate);
+      existingEvent.setEnd(endDate);
+      existingEvent.setRecurrence(recurrence);
+      // Passing null for attendees/conferences/reminders keeps the existing ones untouched
+      agendaEventService.updateEvent(existingEvent, null, null, null, null, null, false, userIdentityId);
+    } else {
+      Map<String, List<String>> fieldsToUpdate = new HashMap<>();
+      if (summary != null) {
+        fieldsToUpdate.put("summary", Collections.singletonList(summary));
+      }
+      if (description != null) {
+        fieldsToUpdate.put("description", Collections.singletonList(description));
+      }
+      if (location != null) {
+        fieldsToUpdate.put("location", Collections.singletonList(location));
+      }
+      if (start != null) {
+        fieldsToUpdate.put("start", Collections.singletonList(start));
+      }
+      if (end != null) {
+        fieldsToUpdate.put("end", Collections.singletonList(end));
+      }
+      if (!fieldsToUpdate.isEmpty()) {
+        agendaEventService.updateEventFields(eventId, fieldsToUpdate, false, false, userIdentityId);
+      }
     }
-    if (start != null) {
-      fieldsToUpdate.put("start", Collections.singletonList(start));
-    }
-    if (end != null) {
-      fieldsToUpdate.put("end", Collections.singletonList(end));
-    }
-    agendaEventService.updateEventFields(eventId,
-                                         fieldsToUpdate,
-                                         false,
-                                         false,
-                                         getCurrentUserIdentityId());
-    return getAgendaEventById(eventId);
+    AgendaEventModel model = getAgendaEventById(eventId);
+    model.setConflicts(conflicts);
+    return model;
   }
 
   public void deleteAgendaEvent(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
@@ -404,6 +505,562 @@ public class AgendaEventMcpTool implements McpToolPlugin {
       throw new IllegalAccessException("User isn't allowed to delete the event with id %s".formatted(eventId));
     }
     agendaEventService.deleteEventById(eventId, getCurrentUserIdentityId());
+  }
+
+  // ==========================================================================
+  // Date polls (expose AgendaEventDatePollService)
+  // ==========================================================================
+
+  // Create a date poll: a TENTATIVE event carrying several proposed slots that attendees can vote on.
+  // Each proposed slot is a "<startRFC3339>|<endRFC3339>" string. When rank_slots_by_availability is true,
+  // slots are ordered so the ones with the most available internal attendees come first.
+  public DatePollModel createDatePoll(Long spaceId,
+                                      String title,
+                                      List<String> proposedSlots,
+                                      List<String> attendeeUsernames,
+                                      String description,
+                                      Boolean rankSlotsByAvailability) throws IllegalAccessException,
+                                                                       ObjectNotFoundException,
+                                                                       AgendaException {
+    if (spaceId == null || spaceId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_SPACE_ID_MANDATORY);
+    } else if (CollectionUtils.isEmpty(proposedSlots)) {
+      throw new IllegalArgumentException("Parameter 'proposed_slots' is mandatory (at least one '<start>|<end>' slot)");
+    } else if (!userAcl.hasPermission(SpaceAclPlugin.OBJECT_TYPE,
+                                      String.valueOf(spaceId),
+                                      SpaceAclPlugin.REDACT_PERMISSION_TYPE,
+                                      getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_CREATE_EVENT.formatted(spaceId));
+    }
+    long userIdentityId = getCurrentUserIdentityId();
+    List<EventAttendee> attendees = toEventAttendees(attendeeUsernames, true);
+    List<EventDateOption> dateOptions = new ArrayList<>();
+    for (String slot : proposedSlots) {
+      String[] parts = slot.split("\\|");
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("Invalid slot '%s', expected '<startRFC3339>|<endRFC3339>'".formatted(slot));
+      }
+      dateOptions.add(new EventDateOption(0l, 0l, toZonedDateTime(parts[0].trim()), toZonedDateTime(parts[1].trim()), false, false, null));
+    }
+    if (Boolean.TRUE.equals(rankSlotsByAvailability)) {
+      dateOptions = rankDateOptionsByAvailability(dateOptions, attendees, userIdentityId);
+    }
+    ZonedDateTime overallStart = dateOptions.stream().map(EventDateOption::getStart).min(Comparator.naturalOrder()).orElseThrow();
+    ZonedDateTime overallEnd = dateOptions.stream().map(EventDateOption::getEnd).max(Comparator.naturalOrder()).orElseThrow();
+    Event event = new Event(0l,
+                            0l,
+                            getSpaceCalendarId(spaceId),
+                            userIdentityId,
+                            0l,
+                            ZonedDateTime.now(),
+                            ZonedDateTime.now(),
+                            title,
+                            description,
+                            null,
+                            null,
+                            TIMEZONE,
+                            overallStart,
+                            overallEnd,
+                            false,
+                            EventAvailability.DEFAULT,
+                            EventStatus.TENTATIVE,
+                            null,
+                            null,
+                            new EventPermission(true, true),
+                            true,
+                            true);
+    Event createdEvent = agendaEventService.createEvent(event,
+                                                        attendees,
+                                                        null,
+                                                        getDefaultUserEventReminders(),
+                                                        dateOptions,
+                                                        null,
+                                                        true,
+                                                        userIdentityId);
+    return getDatePollResults(createdEvent.getId());
+  }
+
+  // Cast the current user's votes on a date poll: accepted_slot_ids are the date-option ids the user accepts.
+  public DatePollModel voteDatePoll(Long eventId, List<Long> acceptedSlotIds) throws ObjectNotFoundException,
+                                                                              IllegalAccessException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    agendaEventDatePollService.saveEventVotes(eventId,
+                                              acceptedSlotIds == null ? Collections.emptyList() : acceptedSlotIds,
+                                              getCurrentUserIdentityId());
+    return getDatePollResults(eventId);
+  }
+
+  // Return the current tally of a date poll: each proposed slot with its vote count and the usernames who voted.
+  public DatePollModel getDatePollResults(long eventId) throws ObjectNotFoundException, IllegalAccessException {
+    if (eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    Event event = agendaEventService.getEventById(eventId, TIMEZONE, getCurrentUserIdentityId());
+    if (event == null) {
+      throw new ObjectNotFoundException("Agenda Event with id %s not found".formatted(eventId));
+    }
+    List<EventDateOption> options = agendaEventDatePollService.getEventDateOptions(eventId, TIMEZONE);
+    List<DatePollOptionModel> optionModels = options.stream().map(this::toDatePollOptionModel).toList();
+    return new DatePollModel(eventId, event.getSummary(), optionModels);
+  }
+
+  // Confirm a date poll by picking a winning slot: converts the poll into a normal confirmed event on that slot,
+  // then re-computes and returns the attendee conflict report for the newly confirmed window.
+  public AgendaEventModel confirmDatePoll(Long dateOptionId) throws ObjectNotFoundException, IllegalAccessException {
+    if (dateOptionId == null || dateOptionId == 0) {
+      throw new IllegalArgumentException("Parameter 'date_option_id' is mandatory");
+    }
+    EventDateOption dateOption = agendaEventDatePollService.getEventDateOption(dateOptionId, TIMEZONE);
+    if (dateOption == null) {
+      throw new ObjectNotFoundException("Event Date Option with id %s not found".formatted(dateOptionId));
+    }
+    long eventId = dateOption.getEventId();
+    if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
+    }
+    long userIdentityId = getCurrentUserIdentityId();
+    agendaEventService.selectEventDateOption(eventId, dateOptionId, userIdentityId);
+    AgendaEventModel model = getAgendaEventById(eventId);
+    List<EventAttendee> attendees = getExistingEventAttendees(eventId);
+    ConflictsModel conflicts = computeConflicts(attendees,
+                                                dateOption.getStart(),
+                                                dateOption.getEnd(),
+                                                userIdentityId);
+    model.setConflicts(conflicts);
+    return model;
+  }
+
+  // ==========================================================================
+  // Free / busy + suggestions (new scheduling logic)
+  // ==========================================================================
+
+  // Return per-user availability (busy and free time blocks) within [start,end].
+  // Privacy: only time ranges are returned, never event titles or details of other users.
+  public List<AvailabilityModel> getAvailability(List<String> usernames,
+                                                 String start,
+                                                 String end) throws IllegalAccessException {
+    if (CollectionUtils.isEmpty(usernames)) {
+      throw new IllegalArgumentException("Parameter 'usernames' is mandatory");
+    }
+    ZonedDateTime windowStart = toZonedDateTime(start);
+    ZonedDateTime windowEnd = toZonedDateTime(end);
+    List<AvailabilityModel> result = new ArrayList<>();
+    for (String username : usernames) {
+      Identity identity = identityManager.getOrCreateUserIdentity(username);
+      if (identity == null) {
+        continue;
+      }
+      List<BusyInterval> intervals = getBusyIntervals(identity.getIdentityId(), windowStart, windowEnd);
+      List<TimeBlockModel> busy = mergeToBlocks(intervals);
+      List<TimeBlockModel> free = complementBlocks(intervals, windowStart, windowEnd);
+      result.add(new AvailabilityModel(username, busy, free));
+    }
+    return result;
+  }
+
+  // Suggest candidate meeting slots of at least duration_minutes where ALL attendees are free within the window.
+  // Optional constraint keywords: "mornings" / "afternoons" restrict candidate start times (before/after 12:00).
+  public List<TimeBlockModel> suggestMeetingTime(List<String> attendees,
+                                                 Integer durationMinutes,
+                                                 String windowStart,
+                                                 String windowEnd,
+                                                 String constraints) throws IllegalAccessException {
+    if (CollectionUtils.isEmpty(attendees)) {
+      throw new IllegalArgumentException(MSG_PARAMETER_ATTENDEE_IS_MANDATORY);
+    }
+    if (durationMinutes == null || durationMinutes <= 0) {
+      throw new IllegalArgumentException("Parameter 'duration_minutes' must be a positive number of minutes");
+    }
+    ZonedDateTime start = toZonedDateTime(windowStart);
+    ZonedDateTime end = toZonedDateTime(windowEnd);
+    // Aggregate everyone's busy intervals, then derive the shared free time
+    List<BusyInterval> allBusy = new ArrayList<>();
+    for (String username : attendees) {
+      Identity identity = identityManager.getOrCreateUserIdentity(username);
+      if (identity != null) {
+        allBusy.addAll(getBusyIntervals(identity.getIdentityId(), start, end));
+      }
+    }
+    List<TimeBlockModel> freeBlocks = complementBlocks(allBusy, start, end);
+    Duration duration = Duration.ofMinutes(durationMinutes);
+    String constraint = constraints == null ? "" : constraints.toLowerCase();
+    boolean morningsOnly = constraint.contains("morning");
+    boolean afternoonsOnly = constraint.contains("afternoon");
+    List<TimeBlockModel> suggestions = new ArrayList<>();
+    for (TimeBlockModel block : freeBlocks) {
+      ZonedDateTime blockStart = toZonedDateTime(block.getStart());
+      ZonedDateTime blockEnd = toZonedDateTime(block.getEnd());
+      ZonedDateTime candidate = blockStart;
+      // Step through the free block in 30-minute increments looking for slots that fit the duration
+      while (!candidate.plus(duration).isAfter(blockEnd)) {
+        int hour = candidate.getHour();
+        boolean hourOk = (!morningsOnly || hour < 12) && (!afternoonsOnly || hour >= 12);
+        if (hourOk) {
+          suggestions.add(new TimeBlockModel(formatDate(Date.from(candidate.toInstant())),
+                                             formatDate(Date.from(candidate.plus(duration).toInstant()))));
+        }
+        candidate = candidate.plusMinutes(30);
+        if (suggestions.size() >= MAX_LIMIT) {
+          return suggestions;
+        }
+      }
+    }
+    return suggestions;
+  }
+
+  // ==========================================================================
+  // Parity tools (attendees, responses, reminders, conference, search)
+  // ==========================================================================
+
+  // List the attendees of an event together with their response (ACCEPTED/DECLINED/TENTATIVE/NEEDS_ACTION).
+  public List<AgendaEventAttendeeModel> getEventAttendees(long eventId) throws IllegalAccessException {
+    if (eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    return getEventAttendees(agendaEventService.getEventById(eventId));
+  }
+
+  // Respond to an event invitation as the current user with ACCEPTED, DECLINED or TENTATIVE (comment is not persisted).
+  public AgendaEventModel respondToAgendaEvent(Long eventId,
+                                               String response,
+                                               String comment) throws ObjectNotFoundException, IllegalAccessException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (StringUtils.isBlank(response)) {
+      throw new IllegalArgumentException("Parameter 'response' is mandatory (ACCEPTED, DECLINED or TENTATIVE)");
+    }
+    EventAttendeeResponse attendeeResponse = EventAttendeeResponse.valueOf(response.trim().toUpperCase());
+    if (attendeeResponse == EventAttendeeResponse.NEEDS_ACTION) {
+      throw new IllegalArgumentException("Response NEEDS_ACTION isn't allowed, use ACCEPTED, DECLINED or TENTATIVE");
+    }
+    if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    agendaEventAttendeeService.sendEventResponse(eventId, getCurrentUserIdentityId(), attendeeResponse);
+    return getAgendaEventById(eventId);
+  }
+
+  // Set the current user's reminders on an event; each reminder is a "<number> <MINUTE|HOUR|DAY|WEEK>" string.
+  public List<String> setEventReminders(Long eventId, List<String> reminders) throws IllegalAccessException, AgendaException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    long userIdentityId = getCurrentUserIdentityId();
+    List<EventReminder> eventReminders = new ArrayList<>();
+    if (reminders != null) {
+      for (String reminder : reminders) {
+        eventReminders.add(parseReminder(reminder, userIdentityId));
+      }
+    }
+    Event event = agendaEventService.getEventById(eventId);
+    agendaEventReminderService.saveEventReminders(event, eventReminders, userIdentityId);
+    return agendaEventReminderService.getEventReminders(eventId, userIdentityId)
+                                     .stream()
+                                     .map(r -> "%s %s".formatted(r.getBefore(), r.getBeforePeriodType()))
+                                     .toList();
+  }
+
+  // Return the web-conference (e.g. Jitsi) link attached to an event, if any.
+  public ConferenceModel getEventConference(long eventId) throws IllegalAccessException {
+    if (eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    List<EventConference> conferences = agendaEventConferenceService.getEventConferences(eventId);
+    if (CollectionUtils.isEmpty(conferences)) {
+      return new ConferenceModel(null, null);
+    }
+    EventConference conference = conferences.get(0);
+    return new ConferenceModel(conference.getType(), conference.getUrl());
+  }
+
+  // Attach (or, when url is blank, remove) a web-conference link on an event. Defaults the type to "web".
+  public ConferenceModel setEventConference(Long eventId, String url, String type) throws IllegalAccessException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
+    }
+    if (StringUtils.isBlank(url)) {
+      agendaEventConferenceService.saveEventConferences(eventId, Collections.emptyList());
+      return new ConferenceModel(null, null);
+    }
+    EventConference conference = new EventConference();
+    conference.setEventId(eventId);
+    conference.setType(StringUtils.isBlank(type) ? "web" : type);
+    conference.setUrl(url);
+    agendaEventConferenceService.saveEventConferences(eventId, Collections.singletonList(conference));
+    return new ConferenceModel(conference.getType(), conference.getUrl());
+  }
+
+  // Keyword search over agenda events the current user can access, optionally restricted to a space.
+  // Note: the underlying search index has no date-range filter, so start/end are applied as a post-filter here.
+  public List<AgendaEventModel> searchAgendaEvents(String query,
+                                                   String start,
+                                                   String end,
+                                                   Long spaceId) {
+    if (StringUtils.isBlank(query)) {
+      throw new IllegalArgumentException("Parameter 'query' is mandatory");
+    }
+    long userIdentityId = getCurrentUserIdentityId();
+    List<Long> spaceIdentityIds = spaceId == null || spaceId == 0 ? null
+                                                                   : getSpaceIdentityIds(Collections.singletonList(spaceId));
+    AgendaEventSearchFilter filter = new AgendaEventSearchFilter(userIdentityId,
+                                                                 TIMEZONE,
+                                                                 query,
+                                                                 spaceIdentityIds,
+                                                                 null,
+                                                                 null,
+                                                                 0,
+                                                                 MAX_LIMIT);
+    List<EventSearchResult> results = agendaEventService.search(filter);
+    ZonedDateTime startFilter = StringUtils.isBlank(start) ? null : toZonedDateTime(start);
+    ZonedDateTime endFilter = StringUtils.isBlank(end) ? null : toZonedDateTime(end);
+    return results.stream()
+                  .filter(event -> startFilter == null || event.getEnd() == null || !event.getEnd().isBefore(startFilter))
+                  .filter(event -> endFilter == null || event.getStart() == null || !event.getStart().isAfter(endFilter))
+                  .map(this::toAgendaEventModel)
+                  .filter(Objects::nonNull)
+                  .toList();
+  }
+
+  // ==========================================================================
+  // Scheduling helpers
+  // ==========================================================================
+
+  // Small internal busy interval carrying a "tentative" flag (event status TENTATIVE) used by free/busy + conflicts.
+  private static final class BusyInterval {
+    private final ZonedDateTime start;
+
+    private final ZonedDateTime end;
+
+    private final boolean       tentative;
+
+    private BusyInterval(ZonedDateTime start, ZonedDateTime end, boolean tentative) {
+      this.start = start;
+      this.end = end;
+      this.tentative = tentative;
+    }
+  }
+
+  // Query the given user's own calendar in [start,end] and return their busy intervals (availability != FREE),
+  // clipped to the window. Reads the target user's calendar acting as that user; only time ranges are used.
+  private List<BusyInterval> getBusyIntervals(long identityId, ZonedDateTime start, ZonedDateTime end) throws IllegalAccessException {
+    EventFilter filter = new EventFilter(identityId,
+                                         null,
+                                         List.of(EventAttendeeResponse.ACCEPTED,
+                                                 EventAttendeeResponse.TENTATIVE,
+                                                 EventAttendeeResponse.NEEDS_ACTION),
+                                         start,
+                                         end,
+                                         BUSY_QUERY_LIMIT);
+    List<Event> events = agendaEventService.getEvents(filter, TIMEZONE, identityId);
+    List<BusyInterval> intervals = new ArrayList<>();
+    for (Event event : events) {
+      if (event.getAvailability() == EventAvailability.FREE || event.getStart() == null || event.getEnd() == null) {
+        continue;
+      }
+      ZonedDateTime clippedStart = event.getStart().isBefore(start) ? start : event.getStart();
+      ZonedDateTime clippedEnd = event.getEnd().isAfter(end) ? end : event.getEnd();
+      if (!clippedStart.isBefore(clippedEnd)) {
+        continue;
+      }
+      intervals.add(new BusyInterval(clippedStart, clippedEnd, event.getStatus() == EventStatus.TENTATIVE));
+    }
+    return intervals;
+  }
+
+  // Merge overlapping busy intervals into a sorted list of busy time blocks.
+  private List<TimeBlockModel> mergeToBlocks(List<BusyInterval> intervals) {
+    List<TimeBlockModel> blocks = new ArrayList<>();
+    List<BusyInterval> sorted = new ArrayList<>(intervals);
+    sorted.sort(Comparator.comparing(i -> i.start));
+    ZonedDateTime curStart = null;
+    ZonedDateTime curEnd = null;
+    for (BusyInterval interval : sorted) {
+      if (curStart == null) {
+        curStart = interval.start;
+        curEnd = interval.end;
+      } else if (!interval.start.isAfter(curEnd)) {
+        if (interval.end.isAfter(curEnd)) {
+          curEnd = interval.end;
+        }
+      } else {
+        blocks.add(toTimeBlock(curStart, curEnd));
+        curStart = interval.start;
+        curEnd = interval.end;
+      }
+    }
+    if (curStart != null) {
+      blocks.add(toTimeBlock(curStart, curEnd));
+    }
+    return blocks;
+  }
+
+  // Compute the free time blocks in [windowStart,windowEnd] left over after removing all busy intervals.
+  private List<TimeBlockModel> complementBlocks(List<BusyInterval> intervals,
+                                                ZonedDateTime windowStart,
+                                                ZonedDateTime windowEnd) {
+    List<TimeBlockModel> busyBlocks = mergeToBlocks(intervals);
+    List<TimeBlockModel> free = new ArrayList<>();
+    ZonedDateTime cursor = windowStart;
+    for (TimeBlockModel busy : busyBlocks) {
+      ZonedDateTime busyStart = toZonedDateTime(busy.getStart());
+      ZonedDateTime busyEnd = toZonedDateTime(busy.getEnd());
+      if (busyStart.isAfter(cursor)) {
+        free.add(toTimeBlock(cursor, busyStart));
+      }
+      if (busyEnd.isAfter(cursor)) {
+        cursor = busyEnd;
+      }
+    }
+    if (cursor.isBefore(windowEnd)) {
+      free.add(toTimeBlock(cursor, windowEnd));
+    }
+    return free;
+  }
+
+  // Build the attendee conflict report for [start,end]: one entry per attendee that overlaps, plus all_available.
+  // Privacy: only busy/tentative status and the overlapping window are returned, never other users' event details.
+  private ConflictsModel computeConflicts(List<EventAttendee> attendees,
+                                          ZonedDateTime start,
+                                          ZonedDateTime end,
+                                          long currentUserId) throws IllegalAccessException {
+    List<AttendeeConflictModel> conflicts = new ArrayList<>();
+    if (attendees != null) {
+      for (EventAttendee attendee : attendees) {
+        Identity identity = identityManager.getIdentity(attendee.getIdentityId());
+        if (identity == null || !identity.isUser()) {
+          continue;
+        }
+        List<BusyInterval> intervals = getBusyIntervals(attendee.getIdentityId(), start, end);
+        if (intervals.isEmpty()) {
+          continue;
+        }
+        ZonedDateTime overlapStart = intervals.stream().map(i -> i.start).min(Comparator.naturalOrder()).orElse(start);
+        ZonedDateTime overlapEnd = intervals.stream().map(i -> i.end).max(Comparator.naturalOrder()).orElse(end);
+        boolean onlyTentative = intervals.stream().allMatch(i -> i.tentative);
+        conflicts.add(new AttendeeConflictModel(identity.getRemoteId(),
+                                                onlyTentative ? "tentative" : "busy",
+                                                toTimeBlock(overlapStart, overlapEnd)));
+      }
+    }
+    return new ConflictsModel(conflicts.isEmpty(), conflicts);
+  }
+
+  // Order date-poll slots so the ones where the most internal attendees are free come first.
+  private List<EventDateOption> rankDateOptionsByAvailability(List<EventDateOption> dateOptions,
+                                                              List<EventAttendee> attendees,
+                                                              long currentUserId) throws IllegalAccessException {
+    Map<EventDateOption, Long> availabilityCount = new LinkedHashMap<>();
+    for (EventDateOption option : dateOptions) {
+      long freeCount = 0;
+      for (EventAttendee attendee : attendees) {
+        Identity identity = identityManager.getIdentity(attendee.getIdentityId());
+        if (identity == null || !identity.isUser()) {
+          continue;
+        }
+        if (getBusyIntervals(attendee.getIdentityId(), option.getStart(), option.getEnd()).isEmpty()) {
+          freeCount++;
+        }
+      }
+      availabilityCount.put(option, freeCount);
+    }
+    return dateOptions.stream()
+                      .sorted(Comparator.comparingLong((EventDateOption o) -> availabilityCount.get(o)).reversed())
+                      .toList();
+  }
+
+  // Build an EventRecurrence from simple frequency/interval/until/count params, or null when no frequency is given.
+  private EventRecurrence buildRecurrence(String frequency, Integer interval, String until, Integer count) {
+    if (StringUtils.isBlank(frequency)) {
+      return null;
+    }
+    EventRecurrenceFrequency recurrenceFrequency = EventRecurrenceFrequency.valueOf(frequency.trim().toUpperCase());
+    EventRecurrence recurrence = new EventRecurrence();
+    recurrence.setFrequency(recurrenceFrequency);
+    recurrence.setInterval(interval == null || interval <= 0 ? 1 : interval);
+    recurrence.setType(toRecurrenceType(recurrenceFrequency));
+    if (count != null && count > 0) {
+      recurrence.setCount(count);
+    } else if (StringUtils.isNotBlank(until)) {
+      recurrence.setUntil(LocalDate.parse(until.trim().substring(0, 10)));
+    }
+    return recurrence;
+  }
+
+  // Map a recurrence frequency to the display recurrence type (CUSTOM for hourly/minutely/secondly).
+  private EventRecurrenceType toRecurrenceType(EventRecurrenceFrequency frequency) {
+    return switch (frequency) {
+      case DAILY -> EventRecurrenceType.DAILY;
+      case WEEKLY -> EventRecurrenceType.WEEKLY;
+      case MONTHLY -> EventRecurrenceType.MONTHLY;
+      case YEARLY -> EventRecurrenceType.YEARLY;
+      default -> EventRecurrenceType.CUSTOM;
+    };
+  }
+
+  // Parse a "<number> <MINUTE|HOUR|DAY|WEEK>" reminder string into an EventReminder for the given user.
+  private EventReminder parseReminder(String reminder, long userIdentityId) {
+    if (StringUtils.isBlank(reminder)) {
+      throw new IllegalArgumentException("Empty reminder, expected '<number> <MINUTE|HOUR|DAY|WEEK>'");
+    }
+    String[] parts = reminder.trim().split("\\s+");
+    if (parts.length != 2) {
+      throw new IllegalArgumentException("Invalid reminder '%s', expected '<number> <MINUTE|HOUR|DAY|WEEK>'".formatted(reminder));
+    }
+    int before = Integer.parseInt(parts[0]);
+    ReminderPeriodType periodType = ReminderPeriodType.valueOf(parts[1].toUpperCase());
+    return new EventReminder(userIdentityId, before, periodType);
+  }
+
+  // Load an event's current attendees as EventAttendee list (empty when none), used for conflict computation.
+  private List<EventAttendee> getExistingEventAttendees(long eventId) {
+    EventAttendeeList attendeeList = agendaEventAttendeeService.getEventAttendees(eventId);
+    return attendeeList == null || attendeeList.getEventAttendees() == null ? Collections.emptyList()
+                                                                            : attendeeList.getEventAttendees();
+  }
+
+  // Map an EventDateOption to its DTO with vote count and voter usernames.
+  private DatePollOptionModel toDatePollOptionModel(EventDateOption option) {
+    List<String> voters = option.getVoters() == null ? Collections.emptyList()
+                                                      : option.getVoters()
+                                                              .stream()
+                                                              .map(identityManager::getIdentity)
+                                                              .filter(Objects::nonNull)
+                                                              .filter(Identity::isUser)
+                                                              .map(Identity::getRemoteId)
+                                                              .toList();
+    return new DatePollOptionModel(option.getId(),
+                                   formatDate(Date.from(option.getStart().toInstant())),
+                                   formatDate(Date.from(option.getEnd().toInstant())),
+                                   option.isAllDay(),
+                                   option.isSelected(),
+                                   voters.size(),
+                                   voters);
+  }
+
+  // Build a TimeBlockModel (RFC3339 start/end) from two ZonedDateTime bounds.
+  private TimeBlockModel toTimeBlock(ZonedDateTime start, ZonedDateTime end) {
+    return new TimeBlockModel(formatDate(Date.from(start.toInstant())), formatDate(Date.from(end.toInstant())));
   }
 
   @SneakyThrows
@@ -434,7 +1091,8 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                 event.isAllDay(),
                                 eventAttendees,
                                 userAnswer,
-                                getUserModel(event.getCreatorId()));
+                                getUserModel(event.getCreatorId()),
+                                null);
   }
 
   private List<EventAttendee> toEventAttendees(List<String> attendeeUsernames, boolean includeCurrentUser) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
@@ -1,0 +1,594 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp;
+
+import static io.meeds.mcp.server.tool.util.SpaceToolUtils.toSpaceModel;
+import static io.meeds.mcp.server.tool.util.UserToolUtils.toUserModel;
+import static io.meeds.mcp.server.util.McpToolUtils.formatDate;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.agenda.constant.EventAttendeeResponse;
+import org.exoplatform.agenda.constant.EventAvailability;
+import org.exoplatform.agenda.constant.EventStatus;
+import org.exoplatform.agenda.exception.AgendaException;
+import org.exoplatform.agenda.mcp.model.AgendaEventAttendeeModel;
+import org.exoplatform.agenda.mcp.model.AgendaEventCollectionModel;
+import org.exoplatform.agenda.mcp.model.AgendaEventModel;
+import org.exoplatform.agenda.model.AgendaUserSettings;
+import org.exoplatform.agenda.model.Calendar;
+import org.exoplatform.agenda.model.Event;
+import org.exoplatform.agenda.model.EventAttendee;
+import org.exoplatform.agenda.model.EventAttendeeList;
+import org.exoplatform.agenda.model.EventConference;
+import org.exoplatform.agenda.model.EventFilter;
+import org.exoplatform.agenda.model.EventPermission;
+import org.exoplatform.agenda.model.EventReminder;
+import org.exoplatform.agenda.model.EventReminderParameter;
+import org.exoplatform.agenda.plugin.AgendaEventAclPlugin;
+import org.exoplatform.agenda.plugin.AgendaEventPermanentLinkPlugin;
+import org.exoplatform.agenda.service.AgendaCalendarService;
+import org.exoplatform.agenda.service.AgendaEventAttendeeService;
+import org.exoplatform.agenda.service.AgendaEventConferenceService;
+import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.agenda.service.AgendaUserSettingsService;
+import org.exoplatform.agenda.util.AgendaDateUtils;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+import org.exoplatform.social.core.space.SpaceUtils;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.mcp.server.plugin.McpToolPlugin;
+import io.meeds.mcp.server.tool.model.SpaceModel;
+import io.meeds.mcp.server.tool.model.UserModel;
+import io.meeds.portal.permlink.model.PermanentLinkObject;
+import io.meeds.portal.permlink.service.PermanentLinkService;
+import io.meeds.social.space.plugin.SpaceAclPlugin;
+import io.meeds.social.translation.service.TranslationService;
+
+import lombok.SneakyThrows;
+
+@Service
+@Profile("mcp-server")
+public class AgendaEventMcpTool implements McpToolPlugin {
+
+  private static final String                MSG_USER_NOT_ALLOWED_TO_ACCESS_SPACE =
+                                                                                  "User isn't allowed to access the space with id %s";
+
+  private static final String                MSG_USER_NOT_ALLOWED_TO_CREATE_EVENT =
+                                                                                  "User isn't allowed to create events in space with id %s";
+
+  private static final String                MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT =
+                                                                                  "User isn't allowed to access event with id %s";
+
+  private static final String                MSG_PARAMETER_SPACE_ID_MANDATORY     = "parameter 'space_id' is mandatory";
+
+  private static final String                MSG_PARAMETER_EVENT_ID_MADATORY      = "Parameter 'event_id' is madatory";
+
+  private static final String                MSG_PARAMETER_ATTENDEE_IS_MANDATORY  = "Parameter 'attendee_usernames' is mandatory";
+
+  private static final String                MSG_USER_NOT_ALLOWED_TO_UPDATE       =
+                                                                            "User isn't allowed to update the event with id %s";
+
+  private static final ZoneOffset            TIMEZONE                             = ZoneOffset.UTC;
+
+  private static final int                   MAX_LIMIT                            = 100;
+
+  private final SpaceService                 spaceService;
+
+  private final IdentityManager              identityManager;
+
+  private final AgendaCalendarService        agendaCalendarService;
+
+  private final AgendaEventService           agendaEventService;
+
+  private final AgendaEventAttendeeService   agendaEventAttendeeService;
+
+  private final AgendaEventConferenceService agendaEventConferenceService;
+
+  private final AgendaUserSettingsService    agendaUserSettingsService;
+
+  private final ProfilePropertyService       profilePropertyService;
+
+  private final UserACL                      userAcl;
+
+  private final TranslationService           translationService;
+
+  private final PermanentLinkService         permanentLinkService;
+
+  private final UserPortalConfigService      portalConfigService;
+
+  @Autowired
+  public AgendaEventMcpTool(AgendaCalendarService agendaCalendarService, // NOSONAR
+                            AgendaEventService agendaEventService,
+                            AgendaEventConferenceService agendaEventConferenceService,
+                            AgendaEventAttendeeService agendaEventAttendeeService,
+                            AgendaUserSettingsService agendaUserSettingsService,
+                            UserPortalConfigService portalConfigService,
+                            ProfilePropertyService profilePropertyService,
+                            PermanentLinkService permanentLinkService,
+                            TranslationService translationService,
+                            IdentityManager identityManager,
+                            SpaceService spaceService,
+                            UserACL userAcl) {
+    this.agendaEventService = agendaEventService;
+    this.agendaEventAttendeeService = agendaEventAttendeeService;
+    this.agendaEventConferenceService = agendaEventConferenceService;
+    this.agendaUserSettingsService = agendaUserSettingsService;
+    this.agendaCalendarService = agendaCalendarService;
+    this.profilePropertyService = profilePropertyService;
+    this.portalConfigService = portalConfigService;
+    this.permanentLinkService = permanentLinkService;
+    this.translationService = translationService;
+    this.identityManager = identityManager;
+    this.spaceService = spaceService;
+    this.userAcl = userAcl;
+  }
+
+  public AgendaEventCollectionModel getAgendaEvents(String start,
+                                                    String end,
+                                                    Long spaceId,
+                                                    Integer limit) throws IllegalAccessException {
+    if (limit == null) {
+      limit = 0;
+    }
+    ZonedDateTime startDatetime = StringUtils.isBlank(start) ? ZonedDateTime.now(TIMEZONE) :
+                                                             toZonedDateTime(start);
+    ZonedDateTime endDatetime = null;
+    if (StringUtils.isBlank(end)) {
+      if (limit <= 0) {
+        limit = 10;
+      }
+    } else {
+      endDatetime = toZonedDateTime(end);
+    }
+    limit = Math.min(limit, MAX_LIMIT);
+    long userIdentityId = getCurrentUserIdentityId();
+    List<Long> ownerIds = spaceId == null || spaceId.longValue() == 0 ? null :
+                                                                      getSpaceIdentityIds(Collections.singletonList(spaceId));
+    EventFilter eventFilter = new EventFilter(userIdentityId,
+                                              ownerIds,
+                                              List.of(EventAttendeeResponse.ACCEPTED,
+                                                      EventAttendeeResponse.TENTATIVE,
+                                                      EventAttendeeResponse.NEEDS_ACTION),
+                                              startDatetime,
+                                              endDatetime,
+                                              limit);
+    List<Event> events = agendaEventService.getEvents(eventFilter, TIMEZONE, userIdentityId);
+    List<AgendaEventModel> eventEntities = events.stream()
+                                                 .map(this::toAgendaEventModel)
+                                                 .filter(Objects::nonNull)
+                                                 .toList();
+    return new AgendaEventCollectionModel(eventEntities, start, end, limit);
+  }
+
+  public AgendaEventModel getAgendaEventById(long eventId) throws ObjectNotFoundException, IllegalAccessException {
+    Event event = agendaEventService.getEventById(eventId, TIMEZONE, getCurrentUserIdentityId());
+    if (event == null) {
+      throw new ObjectNotFoundException("Agenda Event with id %s not found");
+    }
+    return toAgendaEventModel(event);
+  }
+
+  public AgendaEventModel createAgendaEvent(Long spaceId,
+                                            String summary,
+                                            String description,
+                                            String location,
+                                            String start,
+                                            String end,
+                                            List<String> attendeeUsernames) throws IllegalAccessException,
+                                                                            ObjectNotFoundException,
+                                                                            AgendaException {
+    if (spaceId == null || spaceId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_SPACE_ID_MANDATORY);
+    } else if (!userAcl.hasPermission(SpaceAclPlugin.OBJECT_TYPE,
+                                      String.valueOf(spaceId),
+                                      SpaceAclPlugin.REDACT_PERMISSION_TYPE,
+                                      getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_CREATE_EVENT.formatted(spaceId));
+    }
+    long userIdentityId = getCurrentUserIdentityId();
+    ZonedDateTime startDate = toZonedDateTime(start);
+    ZonedDateTime endDate = toZonedDateTime(end);
+    Event event = new Event(0l,
+                            0l,
+                            getSpaceCalendarId(spaceId),
+                            userIdentityId,
+                            0l,
+                            ZonedDateTime.now(),
+                            ZonedDateTime.now(),
+                            summary,
+                            description,
+                            location,
+                            null,
+                            TIMEZONE,
+                            startDate,
+                            endDate,
+                            false,
+                            EventAvailability.DEFAULT,
+                            EventStatus.CONFIRMED,
+                            null,
+                            null,
+                            new EventPermission(true, true),
+                            true,
+                            true);
+    Event createdEvent = agendaEventService.createEvent(event,
+                                                        toEventAttendees(attendeeUsernames, true),
+                                                        null,
+                                                        getDefaultUserEventReminders(),
+                                                        null,
+                                                        null,
+                                                        true,
+                                                        userIdentityId);
+    return toAgendaEventModel(createdEvent);
+  }
+
+  public void declineAgendaEventInvitation(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    } else if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE,
+                                            String.valueOf(eventId),
+                                            getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    agendaEventAttendeeService.sendEventResponse(eventId, getCurrentUserIdentityId(), EventAttendeeResponse.DECLINED);
+  }
+
+  public void cancelAgendaEvent(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
+    declineAgendaEventInvitation(eventId);
+  }
+
+  public void acceptAgendaEventInvitation(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    } else if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE,
+                                            String.valueOf(eventId),
+                                            getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
+    }
+    agendaEventAttendeeService.sendEventResponse(eventId, getCurrentUserIdentityId(), EventAttendeeResponse.ACCEPTED);
+  }
+
+  public AgendaEventModel inviteUsersToAgendaEvent(Long eventId, List<String> attendeeUsernames) throws IllegalAccessException,
+                                                                                                 ObjectNotFoundException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    } else if (CollectionUtils.isEmpty(attendeeUsernames)) {
+      throw new IllegalArgumentException(MSG_PARAMETER_ATTENDEE_IS_MANDATORY);
+    } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
+                                          String.valueOf(eventId),
+                                          getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
+    }
+    EventAttendeeList attendeeList = agendaEventAttendeeService.getEventAttendees(eventId);
+    List<EventAttendee> existingAttendees = attendeeList.getEventAttendees() == null ? Collections.emptyList() :
+                                                                                     attendeeList.getEventAttendees();
+    List<String> existingAttendeeUsernames = existingAttendees.stream()
+                                                              .map(eat -> eat.getIdentityId())
+                                                              .map(identityManager::getIdentity)
+                                                              .filter(Identity::isUser)
+                                                              .map(Identity::getRemoteId)
+                                                              .toList();
+    List<EventAttendee> attendees = toEventAttendees(attendeeUsernames.stream()
+                                                                      .filter(u -> !existingAttendeeUsernames.contains(u))
+                                                                      .toList(),
+                                                     false);
+    attendees.addAll(existingAttendees);
+    agendaEventAttendeeService.saveEventAttendees(agendaEventService.getEventById(eventId),
+                                                  attendees,
+                                                  getCurrentUserIdentityId(),
+                                                  false,
+                                                  false,
+                                                  null);
+    return getAgendaEventById(eventId);
+  }
+
+  public AgendaEventModel inviteSpaceToAgendaEvent(Long eventId, Long spaceId) throws IllegalAccessException,
+                                                                               ObjectNotFoundException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    } else if (spaceId == null || spaceId == 0) {
+      throw new IllegalArgumentException("Parameter 'space_id' is mandatory");
+    } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
+                                          String.valueOf(eventId),
+                                          getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
+    } else if (!userAcl.hasAccessPermission(SpaceAclPlugin.OBJECT_TYPE,
+                                            String.valueOf(spaceId),
+                                            getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_SPACE.formatted(spaceId));
+    }
+    EventAttendeeList attendeeList = agendaEventAttendeeService.getEventAttendees(eventId);
+    List<EventAttendee> existingAttendees = attendeeList.getEventAttendees() == null ? Collections.emptyList() :
+                                                                                     attendeeList.getEventAttendees();
+    List<Long> existingAttendeeSpaces = existingAttendees.stream()
+                                                         .map(eat -> eat.getIdentityId())
+                                                         .map(identityManager::getIdentity)
+                                                         .filter(Identity::isSpace)
+                                                         .map(Identity::getRemoteId)
+                                                         .map(spaceService::getSpaceByPrettyName)
+                                                         .filter(Objects::nonNull)
+                                                         .map(Space::getSpaceId)
+                                                         .toList();
+    if (!existingAttendeeSpaces.contains(spaceId)) {
+      List<EventAttendee> attendees = new ArrayList<>(existingAttendees);
+      attendees.add(new EventAttendee(0l, getSpaceIdentityId(spaceId), EventAttendeeResponse.NEEDS_ACTION));
+      agendaEventAttendeeService.saveEventAttendees(agendaEventService.getEventById(eventId),
+                                                    attendees,
+                                                    getCurrentUserIdentityId(),
+                                                    false,
+                                                    false,
+                                                    null);
+    }
+    return getAgendaEventById(eventId);
+  }
+
+  public AgendaEventModel updateAgendaEvent(Long eventId,
+                                            String summary,
+                                            String description,
+                                            String location,
+                                            String start,
+                                            String end) throws IllegalAccessException, ObjectNotFoundException, AgendaException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
+                                          String.valueOf(eventId),
+                                          getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
+    }
+    Map<String, List<String>> fieldsToUpdate = new HashMap<>();
+    if (summary != null) {
+      fieldsToUpdate.put("summary", Collections.singletonList(summary));
+    }
+    if (description != null) {
+      fieldsToUpdate.put("description", Collections.singletonList(description));
+    }
+    if (location != null) {
+      fieldsToUpdate.put("location", Collections.singletonList(location));
+    }
+    if (start != null) {
+      fieldsToUpdate.put("start", Collections.singletonList(start));
+    }
+    if (end != null) {
+      fieldsToUpdate.put("end", Collections.singletonList(end));
+    }
+    agendaEventService.updateEventFields(eventId,
+                                         fieldsToUpdate,
+                                         false,
+                                         false,
+                                         getCurrentUserIdentityId());
+    return getAgendaEventById(eventId);
+  }
+
+  public void deleteAgendaEvent(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    } else if (!userAcl.hasDeletePermission(AgendaEventAclPlugin.OBJECT_TYPE,
+                                            String.valueOf(eventId),
+                                            getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException("User isn't allowed to delete the event with id %s".formatted(eventId));
+    }
+    agendaEventService.deleteEventById(eventId, getCurrentUserIdentityId());
+  }
+
+  @SneakyThrows
+  private AgendaEventModel toAgendaEventModel(Event event) {
+    List<AgendaEventAttendeeModel> eventAttendees = getEventAttendees(event);
+    String currentUsername = getCurrentUserName();
+    EventAttendeeResponse userAnswer = eventAttendees == null ? null :
+                                                              eventAttendees.stream()
+                                                                            .filter(eat -> eat.getUser() != null
+                                                                                           && StringUtils.equals(eat.getUser()
+                                                                                                                    .getUsername(),
+                                                                                                                 currentUsername))
+                                                                            .map(AgendaEventAttendeeModel::getResponse)
+                                                                            .findFirst()
+                                                                            .orElse(null);
+    return new AgendaEventModel(event.getId(),
+                                event.getParentId(),
+                                getCalendarSpaceId(event.getCalendarId()),
+                                event.getSummary(),
+                                event.getDescription(),
+                                formatDate(Date.from(event.getStart()
+                                                          .toInstant())),
+                                formatDate(Date.from(event.getEnd()
+                                                          .toInstant())),
+                                event.getLocation(),
+                                getUrl(event.getId()),
+                                getConferenceUrl(event),
+                                event.isAllDay(),
+                                eventAttendees,
+                                userAnswer,
+                                getUserModel(event.getCreatorId()));
+  }
+
+  private List<EventAttendee> toEventAttendees(List<String> attendeeUsernames, boolean includeCurrentUser) {
+    List<EventAttendee> attendees = CollectionUtils.isEmpty(attendeeUsernames) ?
+                                                                               Collections.emptyList() :
+                                                                               attendeeUsernames.stream()
+                                                                                                .map(identityManager::getOrCreateUserIdentity)
+                                                                                                .filter(Objects::nonNull)
+                                                                                                .map(i -> new EventAttendee(0l,
+                                                                                                                            i.getIdentityId(),
+                                                                                                                            EventAttendeeResponse.NEEDS_ACTION))
+                                                                                                .toList();
+    attendees = new ArrayList<>(attendees);
+    if (includeCurrentUser) {
+      attendees.add(new EventAttendee(0l,
+                                      getCurrentUserIdentityId(),
+                                      EventAttendeeResponse.ACCEPTED));
+    }
+    return attendees;
+  }
+
+  private long getCalendarSpaceId(long calendarId) {
+    Calendar agendaCalendar = agendaCalendarService.getCalendarById(calendarId);
+    long ownerIdentityId = agendaCalendar.getOwnerId();
+    Identity ownerIdentity = identityManager.getIdentity(ownerIdentityId);
+    if (ownerIdentity == null || ownerIdentity.isDeleted()) {
+      return 0l;
+    } else {
+      Space space = spaceService.getSpaceByPrettyName(ownerIdentity.getRemoteId());
+      return space.getSpaceId();
+    }
+  }
+
+  private long getSpaceCalendarId(long spaceId) throws ObjectNotFoundException {
+    Space space = spaceService.getSpaceById(spaceId);
+    if (space == null) {
+      throw new ObjectNotFoundException("Space with id %s not found".formatted(spaceId));
+    }
+    Identity ownerIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    Calendar agendaCalendar = agendaCalendarService.getOrCreateCalendarByOwnerId(ownerIdentity.getIdentityId());
+    return agendaCalendar.getId();
+  }
+
+  private List<Long> getSpaceIdentityIds(List<Long> spaceIds) {
+    if (CollectionUtils.isEmpty(spaceIds)) {
+      return Collections.emptyList();
+    }
+    List<String> spaceIdsString = spaceIds.stream().map(String::valueOf).toList();
+    return SpaceUtils.getSpaceIdentityIds(getCurrentUserName(), spaceIdsString).stream().map(Long::valueOf).toList();
+  }
+
+  private long getSpaceIdentityId(long spaceId) {
+    Space space = spaceService.getSpaceById(spaceId);
+    Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+    return spaceIdentity.getIdentityId();
+  }
+
+  private String getConferenceUrl(Event event) {
+    long eventId = isComputedOccurrence(event) ? event.getParentId() : event.getId();
+    List<EventConference> eventConferences = agendaEventConferenceService.getEventConferences(eventId);
+    if (CollectionUtils.isEmpty(eventConferences)) {
+      return null;
+    } else {
+      return eventConferences.stream()
+                             .map(EventConference::getUrl)
+                             .filter(StringUtils::isNotBlank)
+                             .findFirst()
+                             .orElse(null);
+    }
+  }
+
+  private String getUrl(long eventId) throws ObjectNotFoundException {
+    return "%s%s".formatted(CommonsUtils.getCurrentDomain(),
+                            permanentLinkService.getLink(new PermanentLinkObject(AgendaEventPermanentLinkPlugin.OBJECT_TYPE,
+                                                                                 String.valueOf(eventId))));
+  }
+
+  private List<AgendaEventAttendeeModel> getEventAttendees(Event event) {
+    long eventId = isComputedOccurrence(event) ? event.getParentId() : event.getId();
+    EventAttendeeList eventAttendeeList = agendaEventAttendeeService.getEventAttendees(eventId);
+    if (eventAttendeeList == null || CollectionUtils.isEmpty(eventAttendeeList.getEventAttendees())) {
+      return Collections.emptyList();
+    } else {
+      return eventAttendeeList.getEventAttendees()
+                              .stream()
+                              .map(eat -> new AgendaEventAttendeeModel(getUserModel(eat.getIdentityId()),
+                                                                       getSpaceModel(eat.getIdentityId()),
+                                                                       eat.getResponse()))
+                              .toList();
+    }
+  }
+
+  private List<EventReminder> getDefaultUserEventReminders() {
+    long identityId = getCurrentUserIdentityId();
+    AgendaUserSettings agendaUserSettings = agendaUserSettingsService.getAgendaUserSettings(identityId);
+    List<EventReminderParameter> reminderParameters = agendaUserSettings.getReminders();
+    if (reminderParameters != null && !reminderParameters.isEmpty()) {
+      return reminderParameters.stream()
+                               .map(reminderParameter -> new EventReminder(identityId,
+                                                                           reminderParameter.getBefore(),
+                                                                           reminderParameter.getBeforePeriodType()))
+                               .toList();
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  private boolean isComputedOccurrence(Event event) {
+    return event.getId() == 0 && event.getParentId() > 0;
+  }
+
+  private UserModel getUserModel(long identityId) {
+    if (identityId == 0) {
+      return null;
+    } else {
+      Locale locale = getCurrentUserLocale();
+      Identity userIdentity = identityManager.getIdentity(identityId);
+      if (userIdentity == null || !userIdentity.isUser()) {
+        return null;
+      } else {
+        return toUserModel(identityManager,
+                           profilePropertyService,
+                           userAcl,
+                           translationService,
+                           portalConfigService,
+                           userIdentity.getRemoteId(),
+                           getCurrentUserName(),
+                           locale,
+                           false);
+      }
+    }
+  }
+
+  private SpaceModel getSpaceModel(long identityId) {
+    if (identityId == 0) {
+      return null;
+    } else {
+      Identity spaceIdentity = identityManager.getIdentity(identityId);
+      if (spaceIdentity == null || !spaceIdentity.isSpace()) {
+        return null;
+      } else {
+        return toSpaceModel(spaceService,
+                            spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId()),
+                            getCurrentUserName());
+      }
+    }
+  }
+
+  private ZonedDateTime toZonedDateTime(String dateString) {
+    return AgendaDateUtils.parseRFC3339ToZonedDateTime(dateString, TIMEZONE);
+  }
+
+  private long getCurrentUserIdentityId() {
+    return identityManager.getOrCreateUserIdentity(getCurrentUserName()).getIdentityId();
+  }
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -84,6 +85,7 @@ import org.exoplatform.agenda.service.AgendaUserSettingsService;
 import org.exoplatform.agenda.util.AgendaDateUtils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -115,8 +117,6 @@ public class AgendaEventMcpTool implements McpToolPlugin {
 
   private static final String                MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT =
                                                                                   "User isn't allowed to access event with id %s";
-
-  private static final String                MSG_PARAMETER_SPACE_ID_MANDATORY     = "parameter 'space_id' is mandatory";
 
   private static final String                MSG_PARAMETER_EVENT_ID_MADATORY      = "Parameter 'event_id' is madatory";
 
@@ -235,8 +235,9 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     return toAgendaEventModel(event);
   }
 
-  // Create an agenda event, optionally recurrent, with a server-side conflict report over its attendees.
-  // When fail_on_conflict is true and at least one attendee is busy/tentative in the window, creation is aborted.
+  // Create an agenda event in a space calendar, optionally recurrent, with a server-side conflict report over its
+  // attendees. When fail_on_conflict is true and at least one attendee is busy/tentative in the window, creation is
+  // aborted. Every event must belong to a space: pass either space_id or a space name via the 'space' parameter.
   public AgendaEventModel createAgendaEvent(Long spaceId,
                                             String summary,
                                             String description,
@@ -248,18 +249,14 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                             Integer recurrenceInterval,
                                             String recurrenceUntil,
                                             Integer recurrenceCount,
-                                            Boolean failOnConflict) throws IllegalAccessException,
-                                                                    ObjectNotFoundException,
-                                                                    AgendaException {
-    if (spaceId == null || spaceId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_SPACE_ID_MANDATORY);
-    } else if (!userAcl.hasPermission(SpaceAclPlugin.OBJECT_TYPE,
-                                      String.valueOf(spaceId),
-                                      SpaceAclPlugin.REDACT_PERMISSION_TYPE,
-                                      getCurrentUserAclIdentity())) {
-      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_CREATE_EVENT.formatted(spaceId));
-    }
+                                            Boolean failOnConflict,
+                                            String space) throws IllegalAccessException,
+                                                          ObjectNotFoundException,
+                                                          AgendaException {
+    long resolvedSpaceId = resolveSpaceId(spaceId, space);
+    checkSpaceCreatePermission(resolvedSpaceId);
     long userIdentityId = getCurrentUserIdentityId();
+    long calendarId = getSpaceCalendarId(resolvedSpaceId);
     ZonedDateTime startDate = toZonedDateTime(start);
     ZonedDateTime endDate = toZonedDateTime(end);
     List<EventAttendee> attendees = toEventAttendees(attendeeUsernames, true);
@@ -273,7 +270,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
 
     Event event = new Event(0l,
                             0l,
-                            getSpaceCalendarId(spaceId),
+                            calendarId,
                             userIdentityId,
                             0l,
                             ZonedDateTime.now(),
@@ -554,19 +551,15 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                       List<String> proposedSlots,
                                       List<String> attendeeUsernames,
                                       String description,
-                                      Boolean rankSlotsByAvailability) throws IllegalAccessException,
-                                                                       ObjectNotFoundException,
-                                                                       AgendaException {
-    if (spaceId == null || spaceId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_SPACE_ID_MANDATORY);
-    } else if (CollectionUtils.isEmpty(proposedSlots)) {
+                                      Boolean rankSlotsByAvailability,
+                                      String space) throws IllegalAccessException,
+                                                    ObjectNotFoundException,
+                                                    AgendaException {
+    if (CollectionUtils.isEmpty(proposedSlots)) {
       throw new IllegalArgumentException("Parameter 'proposed_slots' is mandatory (at least one '<start>|<end>' slot)");
-    } else if (!userAcl.hasPermission(SpaceAclPlugin.OBJECT_TYPE,
-                                      String.valueOf(spaceId),
-                                      SpaceAclPlugin.REDACT_PERMISSION_TYPE,
-                                      getCurrentUserAclIdentity())) {
-      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_CREATE_EVENT.formatted(spaceId));
     }
+    long resolvedSpaceId = resolveSpaceId(spaceId, space);
+    checkSpaceCreatePermission(resolvedSpaceId);
     long userIdentityId = getCurrentUserIdentityId();
     List<EventAttendee> attendees = toEventAttendees(attendeeUsernames, true);
     List<EventDateOption> dateOptions = new ArrayList<>();
@@ -896,21 +889,22 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     }
   }
 
-  // Query the given user's own calendar in [start,end] and return their busy intervals (availability != FREE),
-  // clipped to the window. Reads the target user's calendar acting as that user; only time ranges are used.
+  // Query the given user's calendar in [start,end] and return their busy intervals, clipped to the window.
+  // "Busy" = events the user has ACCEPTED (the creator is auto-accepted, so owned events are included); merely
+  // invited (NEEDS_ACTION), tentative or declined events do NOT make the user busy. Only time ranges are used.
+  // NOTE: connected remote/CalDAV calendars are NOT included here (see class report) — there is no server-side API
+  // to enumerate another user's remote free/busy; those events are only fetched client-side with the user's creds.
   private List<BusyInterval> getBusyIntervals(long identityId, ZonedDateTime start, ZonedDateTime end) throws IllegalAccessException {
     EventFilter filter = new EventFilter(identityId,
                                          null,
-                                         List.of(EventAttendeeResponse.ACCEPTED,
-                                                 EventAttendeeResponse.TENTATIVE,
-                                                 EventAttendeeResponse.NEEDS_ACTION),
+                                         List.of(EventAttendeeResponse.ACCEPTED),
                                          start,
                                          end,
                                          BUSY_QUERY_LIMIT);
     List<Event> events = agendaEventService.getEvents(filter, TIMEZONE, identityId);
     List<BusyInterval> intervals = new ArrayList<>();
     for (Event event : events) {
-      if (event.getAvailability() == EventAvailability.FREE || event.getStart() == null || event.getEnd() == null) {
+      if (event.getStart() == null || event.getEnd() == null) {
         continue;
       }
       ZonedDateTime clippedStart = event.getStart().isBefore(start) ? start : event.getStart();
@@ -1169,6 +1163,71 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     Identity ownerIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
     Calendar agendaCalendar = agendaCalendarService.getOrCreateCalendarByOwnerId(ownerIdentity.getIdentityId());
     return agendaCalendar.getId();
+  }
+
+  // Resolve the target space id from an explicit space_id or a space name. Every event must belong to a space, so a
+  // clear, actionable error (listing the user's spaces) is raised when neither an id nor a resolvable name is given.
+  private long resolveSpaceId(Long spaceId, String spaceName) {
+    if (spaceId != null && spaceId != 0) {
+      return spaceId;
+    }
+    if (StringUtils.isNotBlank(spaceName)) {
+      Space space = findUserSpaceByName(spaceName.trim());
+      if (space != null) {
+        return space.getSpaceId();
+      }
+      throw new IllegalArgumentException("Space '%s' wasn't found among the spaces you belong to. %s".formatted(spaceName.trim(),
+                                                                                                               mySpacesHint()));
+    }
+    throw new IllegalArgumentException("An event must belong to a space. Please tell me which space to use. %s".formatted(mySpacesHint()));
+  }
+
+  // Find one of the current user's member spaces by pretty name or (case-insensitive) display name.
+  private Space findUserSpaceByName(String spaceName) {
+    Space space = spaceService.getSpaceByPrettyName(spaceName);
+    if (space != null && spaceService.isMember(space, getCurrentUserName())) {
+      return space;
+    }
+    for (Space memberSpace : listUserSpaces(100)) {
+      if (StringUtils.equalsIgnoreCase(memberSpace.getDisplayName(), spaceName)
+          || StringUtils.equalsIgnoreCase(memberSpace.getPrettyName(), spaceName)) {
+        return memberSpace;
+      }
+    }
+    return null;
+  }
+
+  // Short hint listing up to 10 of the current user's spaces to guide the model/user toward picking one.
+  private String mySpacesHint() {
+    List<Space> spaces = listUserSpaces(10);
+    if (spaces.isEmpty()) {
+      return "You don't seem to be a member of any space yet.";
+    }
+    return "You're a member of: " + String.join(", ", spaces.stream().map(Space::getDisplayName).toList()) + ".";
+  }
+
+  // Load up to 'limit' of the current user's member spaces.
+  @SneakyThrows
+  private List<Space> listUserSpaces(int limit) {
+    ListAccess<Space> memberSpaces = spaceService.getMemberSpaces(getCurrentUserName());
+    if (memberSpaces == null) {
+      return Collections.emptyList();
+    }
+    int size = memberSpaces.getSize();
+    if (size <= 0) {
+      return Collections.emptyList();
+    }
+    return Arrays.asList(memberSpaces.load(0, Math.min(size, limit)));
+  }
+
+  // Verify the current user is allowed to create events in the given space (REDACT permission on the space).
+  private void checkSpaceCreatePermission(long spaceId) throws IllegalAccessException {
+    if (!userAcl.hasPermission(SpaceAclPlugin.OBJECT_TYPE,
+                               String.valueOf(spaceId),
+                               SpaceAclPlugin.REDACT_PERMISSION_TYPE,
+                               getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_CREATE_EVENT.formatted(spaceId));
+    }
   }
 
   private List<Long> getSpaceIdentityIds(List<Long> spaceIds) {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
@@ -306,7 +306,9 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     return model;
   }
 
-  // Decline an event invitation; when occurrence_id is given, only that single occurrence (and upcoming ones) is declined.
+  // Decline an event invitation for the current user. When occurrence_id is given this is a "this-and-following"
+  // decline: it declines that occurrence AND every subsequent one of the series (it does not cancel a single date;
+  // for cancelling only one date use cancel_agenda_event with occurrence_id).
   public void declineAgendaEventInvitation(Long eventId, String occurrenceId) throws IllegalAccessException,
                                                                               ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
@@ -326,9 +328,42 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     }
   }
 
-  // Cancel (decline) participation in an event; supports single-occurrence cancellation via occurrence_id.
-  public void cancelAgendaEvent(Long eventId, String occurrenceId) throws IllegalAccessException, ObjectNotFoundException {
-    declineAgendaEventInvitation(eventId, occurrenceId);
+  // Cancel an event. Without occurrence_id, the whole event is declined for the current user.
+  // With occurrence_id, ONLY that single occurrence of a recurring series is removed (occurrences before AND after are
+  // kept), using the canonical eXo pattern: materialize the occurrence as an exceptional occurrence, then mark it
+  // CANCELLED so the series expansion skips exactly that one date.
+  public void cancelAgendaEvent(Long eventId, String occurrenceId) throws IllegalAccessException,
+                                                                   ObjectNotFoundException,
+                                                                   AgendaException {
+    if (eventId == null || eventId == 0) {
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+    }
+    if (StringUtils.isBlank(occurrenceId)) {
+      declineAgendaEventInvitation(eventId, null);
+      return;
+    }
+    if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
+      throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
+    }
+    cancelSingleOccurrence(eventId, toZonedDateTime(occurrenceId), getCurrentUserIdentityId());
+  }
+
+  // Cancel a single occurrence of a recurring event: create the exceptional occurrence for that date, then set its
+  // status to CANCELLED. The computed occurrence for that date is then skipped (an exceptional occurrence exists) and
+  // the cancelled exceptional itself is hidden (event listing only returns CONFIRMED), while every other occurrence
+  // (before and after) is preserved.
+  private void cancelSingleOccurrence(long eventId,
+                                      ZonedDateTime occurrenceId,
+                                      long userIdentityId) throws AgendaException,
+                                                           IllegalAccessException,
+                                                           ObjectNotFoundException {
+    Event exceptionalOccurrence = agendaEventService.saveEventExceptionalOccurrence(eventId, occurrenceId);
+    agendaEventService.updateEventFields(exceptionalOccurrence.getId(),
+                                         Collections.singletonMap("status",
+                                                                  Collections.singletonList(EventStatus.CANCELLED.name())),
+                                         false,
+                                         false,
+                                         userIdentityId);
   }
 
   public void acceptAgendaEventInvitation(Long eventId) throws IllegalAccessException, ObjectNotFoundException {

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/AgendaEventMcpTool.java
@@ -118,7 +118,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   private static final String                MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT =
                                                                                   "User isn't allowed to access event with id %s";
 
-  private static final String                MSG_PARAMETER_EVENT_ID_MADATORY      = "Parameter 'event_id' is madatory";
+  private static final String                MSG_PARAMETER_EVENT_ID_MANDATORY     = "Parameter 'event_id' is mandatory";
 
   private static final String                MSG_PARAMETER_ATTENDEE_IS_MANDATORY  = "Parameter 'attendee_usernames' is mandatory";
 
@@ -230,7 +230,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   public AgendaEventModel getAgendaEventById(long eventId) throws ObjectNotFoundException, IllegalAccessException {
     Event event = agendaEventService.getEventById(eventId, TIMEZONE, getCurrentUserIdentityId());
     if (event == null) {
-      throw new ObjectNotFoundException("Agenda Event with id %s not found");
+      throw new ObjectNotFoundException("Agenda Event with id %s not found".formatted(eventId));
     }
     return toAgendaEventModel(event);
   }
@@ -262,7 +262,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     List<EventAttendee> attendees = toEventAttendees(attendeeUsernames, true);
 
     // Compute the conflict report over the event window before writing anything
-    ConflictsModel conflicts = computeConflicts(attendees, startDate, endDate, userIdentityId);
+    ConflictsModel conflicts = computeConflicts(attendees, startDate, endDate);
     if (Boolean.TRUE.equals(failOnConflict) && !conflicts.isAllAvailable()) {
       throw new IllegalStateException("Event not created: %s attendee(s) have a conflict in the requested window"
           .formatted(conflicts.getConflicts().size()));
@@ -309,7 +309,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   public void declineAgendaEventInvitation(Long eventId, String occurrenceId) throws IllegalAccessException,
                                                                               ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     } else if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE,
                                             String.valueOf(eventId),
                                             getCurrentUserAclIdentity())) {
@@ -333,7 +333,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                                                    ObjectNotFoundException,
                                                                    AgendaException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (StringUtils.isBlank(occurrenceId)) {
       declineAgendaEventInvitation(eventId, null);
@@ -365,7 +365,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
 
   public void acceptAgendaEventInvitation(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     } else if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE,
                                             String.valueOf(eventId),
                                             getCurrentUserAclIdentity())) {
@@ -377,7 +377,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   public AgendaEventModel inviteUsersToAgendaEvent(Long eventId, List<String> attendeeUsernames) throws IllegalAccessException,
                                                                                                  ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     } else if (CollectionUtils.isEmpty(attendeeUsernames)) {
       throw new IllegalArgumentException(MSG_PARAMETER_ATTENDEE_IS_MANDATORY);
     } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
@@ -411,7 +411,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   public AgendaEventModel inviteSpaceToAgendaEvent(Long eventId, Long spaceId) throws IllegalAccessException,
                                                                                ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     } else if (spaceId == null || spaceId == 0) {
       throw new IllegalArgumentException("Parameter 'space_id' is mandatory");
     } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
@@ -464,7 +464,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                                                     ObjectNotFoundException,
                                                                     AgendaException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     } else if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE,
                                           String.valueOf(eventId),
                                           getCurrentUserAclIdentity())) {
@@ -479,7 +479,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     ZonedDateTime startDate = start != null ? toZonedDateTime(start) : existingEvent.getStart();
     ZonedDateTime endDate = end != null ? toZonedDateTime(end) : existingEvent.getEnd();
     List<EventAttendee> attendees = getExistingEventAttendees(eventId);
-    ConflictsModel conflicts = computeConflicts(attendees, startDate, endDate, userIdentityId);
+    ConflictsModel conflicts = computeConflicts(attendees, startDate, endDate);
     if (Boolean.TRUE.equals(failOnConflict) && !conflicts.isAllAvailable()) {
       throw new IllegalStateException("Event not updated: %s attendee(s) have a conflict in the requested window"
           .formatted(conflicts.getConflicts().size()));
@@ -530,7 +530,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
 
   public void deleteAgendaEvent(Long eventId) throws IllegalAccessException, ObjectNotFoundException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     } else if (!userAcl.hasDeletePermission(AgendaEventAclPlugin.OBJECT_TYPE,
                                             String.valueOf(eventId),
                                             getCurrentUserAclIdentity())) {
@@ -543,9 +543,12 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // Date polls (expose AgendaEventDatePollService)
   // ==========================================================================
 
-  // Create a date poll: a TENTATIVE event carrying several proposed slots that attendees can vote on.
-  // Each proposed slot is a "<startRFC3339>|<endRFC3339>" string. When rank_slots_by_availability is true,
-  // slots are ordered so the ones with the most available internal attendees come first.
+  /**
+   * Create a date poll: a TENTATIVE event carrying several proposed slots that attendees can vote on.
+   * Each proposed slot is a "&lt;startRFC3339&gt;|&lt;endRFC3339&gt;" string. When rank_slots_by_availability is
+   * true, slots are ordered so the ones with the most available internal attendees come first. Every poll must
+   * belong to a space: pass either space_id or a space name via the 'space' parameter (resolved to resolvedSpaceId).
+   */
   public DatePollModel createDatePoll(Long spaceId,
                                       String title,
                                       List<String> proposedSlots,
@@ -571,13 +574,13 @@ public class AgendaEventMcpTool implements McpToolPlugin {
       dateOptions.add(new EventDateOption(0l, 0l, toZonedDateTime(parts[0].trim()), toZonedDateTime(parts[1].trim()), false, false, null));
     }
     if (Boolean.TRUE.equals(rankSlotsByAvailability)) {
-      dateOptions = rankDateOptionsByAvailability(dateOptions, attendees, userIdentityId);
+      dateOptions = rankDateOptionsByAvailability(dateOptions, attendees);
     }
     ZonedDateTime overallStart = dateOptions.stream().map(EventDateOption::getStart).min(Comparator.naturalOrder()).orElseThrow();
     ZonedDateTime overallEnd = dateOptions.stream().map(EventDateOption::getEnd).max(Comparator.naturalOrder()).orElseThrow();
     Event event = new Event(0l,
                             0l,
-                            getSpaceCalendarId(spaceId),
+                            getSpaceCalendarId(resolvedSpaceId),
                             userIdentityId,
                             0l,
                             ZonedDateTime.now(),
@@ -612,7 +615,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   public DatePollModel voteDatePoll(Long eventId, List<Long> acceptedSlotIds) throws ObjectNotFoundException,
                                                                               IllegalAccessException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
@@ -626,7 +629,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // Return the current tally of a date poll: each proposed slot with its vote count and the usernames who voted.
   public DatePollModel getDatePollResults(long eventId) throws ObjectNotFoundException, IllegalAccessException {
     if (eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
@@ -660,8 +663,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     List<EventAttendee> attendees = getExistingEventAttendees(eventId);
     ConflictsModel conflicts = computeConflicts(attendees,
                                                 dateOption.getStart(),
-                                                dateOption.getEnd(),
-                                                userIdentityId);
+                                                dateOption.getEnd());
     model.setConflicts(conflicts);
     return model;
   }
@@ -751,7 +753,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // List the attendees of an event together with their response (ACCEPTED/DECLINED/TENTATIVE/NEEDS_ACTION).
   public List<AgendaEventAttendeeModel> getEventAttendees(long eventId) throws IllegalAccessException {
     if (eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
@@ -764,7 +766,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
                                                String response,
                                                String comment) throws ObjectNotFoundException, IllegalAccessException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (StringUtils.isBlank(response)) {
       throw new IllegalArgumentException("Parameter 'response' is mandatory (ACCEPTED, DECLINED or TENTATIVE)");
@@ -783,7 +785,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // Set the current user's reminders on an event; each reminder is a "<number> <MINUTE|HOUR|DAY|WEEK>" string.
   public List<String> setEventReminders(Long eventId, List<String> reminders) throws IllegalAccessException, AgendaException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
@@ -806,7 +808,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // Return the web-conference (e.g. Jitsi) link attached to an event, if any.
   public ConferenceModel getEventConference(long eventId) throws IllegalAccessException {
     if (eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (!userAcl.hasAccessPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_ACCESS_EVENT.formatted(eventId));
@@ -822,7 +824,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // Attach (or, when url is blank, remove) a web-conference link on an event. Defaults the type to "web".
   public ConferenceModel setEventConference(Long eventId, String url, String type) throws IllegalAccessException {
     if (eventId == null || eventId == 0) {
-      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MADATORY);
+      throw new IllegalArgumentException(MSG_PARAMETER_EVENT_ID_MANDATORY);
     }
     if (!userAcl.hasEditPermission(AgendaEventAclPlugin.OBJECT_TYPE, String.valueOf(eventId), getCurrentUserAclIdentity())) {
       throw new IllegalAccessException(MSG_USER_NOT_ALLOWED_TO_UPDATE.formatted(eventId));
@@ -971,8 +973,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
   // Privacy: only busy/tentative status and the overlapping window are returned, never other users' event details.
   private ConflictsModel computeConflicts(List<EventAttendee> attendees,
                                           ZonedDateTime start,
-                                          ZonedDateTime end,
-                                          long currentUserId) throws IllegalAccessException {
+                                          ZonedDateTime end) throws IllegalAccessException {
     List<AttendeeConflictModel> conflicts = new ArrayList<>();
     if (attendees != null) {
       for (EventAttendee attendee : attendees) {
@@ -997,8 +998,7 @@ public class AgendaEventMcpTool implements McpToolPlugin {
 
   // Order date-poll slots so the ones where the most internal attendees are free come first.
   private List<EventDateOption> rankDateOptionsByAvailability(List<EventDateOption> dateOptions,
-                                                              List<EventAttendee> attendees,
-                                                              long currentUserId) throws IllegalAccessException {
+                                                              List<EventAttendee> attendees) throws IllegalAccessException {
     Map<EventDateOption, Long> availabilityCount = new LinkedHashMap<>();
     for (EventDateOption option : dateOptions) {
       long freeCount = 0;
@@ -1143,6 +1143,15 @@ public class AgendaEventMcpTool implements McpToolPlugin {
     return attendees;
   }
 
+  /**
+   * Resolve the space id owning the given calendar, degrading gracefully to 0 when the owner identity is missing,
+   * deleted, or its space can no longer be resolved (stale pretty name / space-deletion race). This method backs
+   * {@link #toAgendaEventModel(Event)}, which every read/list tool funnels through, so a null space must not NPE and
+   * break the whole listing.
+   *
+   * @param calendarId the calendar id whose owning space id is looked up
+   * @return the owning space id, or 0 when it cannot be resolved
+   */
   private long getCalendarSpaceId(long calendarId) {
     Calendar agendaCalendar = agendaCalendarService.getCalendarById(calendarId);
     long ownerIdentityId = agendaCalendar.getOwnerId();
@@ -1151,6 +1160,9 @@ public class AgendaEventMcpTool implements McpToolPlugin {
       return 0l;
     } else {
       Space space = spaceService.getSpaceByPrettyName(ownerIdentity.getRemoteId());
+      if (space == null) {
+        return 0l;
+      }
       return space.getSpaceId();
     }
   }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventAttendeeModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventAttendeeModel.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import org.exoplatform.agenda.constant.EventAttendeeResponse;
+
+import io.meeds.mcp.server.tool.model.SpaceModel;
+import io.meeds.mcp.server.tool.model.UserModel;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class AgendaEventAttendeeModel {
+
+  private UserModel             user;
+
+  private SpaceModel            space;
+
+  private EventAttendeeResponse response;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventCollectionModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventCollectionModel.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class AgendaEventCollectionModel {
+
+  private List<AgendaEventModel> events;
+
+  @JsonProperty("from_date")
+  private String                 fromDate;
+
+  @JsonProperty("to_date")
+  private String                 toDate;
+
+  @JsonProperty("used_limit")
+  private int                    usedLimit;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventModel.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.exoplatform.agenda.constant.EventAttendeeResponse;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.meeds.mcp.server.tool.model.UserModel;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class AgendaEventModel {
+
+  @JsonProperty("event_id")
+  private long                           id;
+
+  @JsonProperty("parent_event_id")
+  private long                           parentEventId;
+
+  private long                           spaceId;
+
+  private String                         summary;
+
+  private String                         description;
+
+  private String                         start;
+
+  private String                         end;
+
+  private String                         location;
+
+  private String                         url;
+
+  @JsonProperty("conference_url")
+  private String                         conferenceUrl;
+
+  @JsonProperty("is_all_day")
+  private boolean                        allDay;
+
+  private List<AgendaEventAttendeeModel> attendees;
+
+  @JsonProperty("user_answer")
+  private EventAttendeeResponse          userAnswer;
+
+  private UserModel                      creator;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AgendaEventModel.java
@@ -70,4 +70,7 @@ public class AgendaEventModel {
 
   private UserModel                      creator;
 
+  // Optional conflict report populated on conflict-aware create/update; omitted (null) on plain reads
+  private ConflictsModel                 conflicts;
+
 }

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AttendeeConflictModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AttendeeConflictModel.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// One attendee's scheduling conflict: status (busy|tentative) plus the overlapping window (no event details)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class AttendeeConflictModel {
+
+  private String         attendee;
+
+  private String         status;
+
+  private TimeBlockModel overlap;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AvailabilityModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/AvailabilityModel.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// Per-user availability: busy and free time blocks only (never event titles/details) to preserve privacy
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class AvailabilityModel {
+
+  private String               username;
+
+  private List<TimeBlockModel> busy;
+
+  private List<TimeBlockModel> free;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/ConferenceModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/ConferenceModel.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// A web conference (e.g. Jitsi) attached to an event
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class ConferenceModel {
+
+  private String type;
+
+  private String url;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/ConflictsModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/ConflictsModel.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// Server-side conflict report over an event's attendees for a given window
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_NULL)
+public class ConflictsModel {
+
+  @JsonProperty("all_available")
+  private boolean                     allAvailable;
+
+  private List<AttendeeConflictModel> conflicts;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/DatePollModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/DatePollModel.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// A date poll (a TENTATIVE event) and its proposed slots with vote tallies
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class DatePollModel {
+
+  @JsonProperty("event_id")
+  private long                      eventId;
+
+  private String                    title;
+
+  private List<DatePollOptionModel> options;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/DatePollOptionModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/DatePollOptionModel.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// One proposed date-poll slot with its current votes
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class DatePollOptionModel {
+
+  @JsonProperty("date_option_id")
+  private long         id;
+
+  private String       start;
+
+  private String       end;
+
+  @JsonProperty("is_all_day")
+  private boolean      allDay;
+
+  private boolean      selected;
+
+  @JsonProperty("vote_count")
+  private int          voteCount;
+
+  private List<String> voters;
+
+}

--- a/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/TimeBlockModel.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/mcp/model/TimeBlockModel.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// Simple [start,end] time range (RFC3339 strings) used by free/busy, suggestions and conflict overlaps
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = Include.NON_EMPTY)
+public class TimeBlockModel {
+
+  private String start;
+
+  private String end;
+
+}

--- a/agenda-services/src/main/resources/ai-tool-definitions.json
+++ b/agenda-services/src/main/resources/ai-tool-definitions.json
@@ -241,7 +241,7 @@
     {
       "name": "decline_agenda_event_invitation",
       "title": "Decline an agenda event invitation",
-      "description": "Decline an agenda event invitation by the current user.",
+      "description": "Decline an agenda event invitation by the current user. With occurrence_id this is a 'this-and-following' decline (that occurrence AND all subsequent occurrences). To cancel only ONE date of a series, use cancel_agenda_event with occurrence_id instead.",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -251,7 +251,7 @@
           },
           "occurrence_id": {
             "type": "string",
-            "description": "Optional occurrence date (RFC3339) of a recurring event; when set, only that occurrence and upcoming ones are declined."
+            "description": "Optional occurrence date (RFC3339) of a recurring event; when set, declines that occurrence AND every following one (this-and-future), not just that single date."
           }
         },
         "required": [
@@ -269,7 +269,7 @@
     {
       "name": "cancel_agenda_event",
       "title": "Cancel an agenda event",
-      "description": "Cancel an agenda event by the current user",
+      "description": "Cancel an agenda event. Without occurrence_id the whole event is declined for the current user. With occurrence_id, ONLY that single occurrence of a recurring series is removed; occurrences before AND after that date are kept.",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -279,7 +279,7 @@
           },
           "occurrence_id": {
             "type": "string",
-            "description": "Optional occurrence date (RFC3339) of a recurring event; when set, only that occurrence and upcoming ones are cancelled."
+            "description": "Optional occurrence date (RFC3339) of a recurring event; when set, cancels ONLY that single occurrence (the rest of the series, before and after, is preserved)."
           }
         },
         "required": [

--- a/agenda-services/src/main/resources/ai-tool-definitions.json
+++ b/agenda-services/src/main/resources/ai-tool-definitions.json
@@ -90,6 +90,26 @@
               "type": "string"
             },
             "description": "List of attendee usernames to invite (the current user is added automatically)."
+          },
+          "recurrence_frequency": {
+            "type": "string",
+            "description": "Optional recurrence frequency: DAILY, WEEKLY, MONTHLY, YEARLY (also HOURLY/MINUTELY/SECONDLY). Omit for a one-off event."
+          },
+          "recurrence_interval": {
+            "type": "integer",
+            "description": "Recurrence interval (e.g. 2 = every 2 weeks). Defaults to 1 when a frequency is given."
+          },
+          "recurrence_until": {
+            "type": "string",
+            "description": "Optional recurrence end date (RFC3339 or YYYY-MM-DD); the series stops on/after this date."
+          },
+          "recurrence_count": {
+            "type": "integer",
+            "description": "Optional number of occurrences; takes precedence over recurrence_until."
+          },
+          "fail_on_conflict": {
+            "type": "boolean",
+            "description": "When true, abort creation if any attendee is busy/tentative in the window. Default false: create anyway and return the conflicts block."
           }
         },
         "required": [
@@ -136,6 +156,26 @@
           "end": {
             "type": "string",
             "description": "New event end datetime (RFC3339)."
+          },
+          "recurrence_frequency": {
+            "type": "string",
+            "description": "Optional recurrence frequency (DAILY/WEEKLY/MONTHLY/YEARLY); setting it turns the event into (or updates) a whole recurring series."
+          },
+          "recurrence_interval": {
+            "type": "integer",
+            "description": "Recurrence interval; defaults to 1 when a frequency is given."
+          },
+          "recurrence_until": {
+            "type": "string",
+            "description": "Optional recurrence end date (RFC3339 or YYYY-MM-DD)."
+          },
+          "recurrence_count": {
+            "type": "integer",
+            "description": "Optional number of occurrences; takes precedence over recurrence_until."
+          },
+          "fail_on_conflict": {
+            "type": "boolean",
+            "description": "When true, abort the update if any attendee is busy/tentative in the (new) window. Default false: update anyway and return the conflicts block."
           }
         },
         "required": [
@@ -208,6 +248,10 @@
           "event_id": {
             "type": "integer",
             "description": "Event id (mandatory, must be non-zero)."
+          },
+          "occurrence_id": {
+            "type": "string",
+            "description": "Optional occurrence date (RFC3339) of a recurring event; when set, only that occurrence and upcoming ones are declined."
           }
         },
         "required": [
@@ -232,6 +276,10 @@
           "event_id": {
             "type": "integer",
             "description": "Event id (mandatory, must be non-zero)."
+          },
+          "occurrence_id": {
+            "type": "string",
+            "description": "Optional occurrence date (RFC3339) of a recurring event; when set, only that occurrence and upcoming ones are cancelled."
           }
         },
         "required": [
@@ -303,6 +351,394 @@
         "openWorldHint": false
       },
       "require_approval": true
+    },
+    {
+      "name": "create_date_poll",
+      "title": "Create a date poll",
+      "description": "Create a date poll: a tentative event with several proposed time slots that attendees can vote on to pick a final date.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "space_id": {
+            "type": "integer",
+            "description": "Space id where the poll (event) is created."
+          },
+          "title": {
+            "type": "string",
+            "description": "Poll / event title."
+          },
+          "proposed_slots": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Proposed slots, each as a single string '<startRFC3339>|<endRFC3339>' (e.g. '2026-02-01T14:00:00Z|2026-02-01T15:00:00Z')."
+          },
+          "attendee_usernames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Usernames invited to vote (the current user is added automatically)."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional poll description."
+          },
+          "rank_slots_by_availability": {
+            "type": "boolean",
+            "description": "When true, order proposed slots so those where the most invited internal users are free come first."
+          }
+        },
+        "required": [
+          "space_id",
+          "title",
+          "proposed_slots"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "vote_date_poll",
+      "title": "Vote on a date poll",
+      "description": "Cast the current user's votes on a date poll by listing the accepted slot (date option) ids.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Poll event id."
+          },
+          "accepted_slot_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Date option ids the current user accepts. An empty list dismisses all options."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "get_date_poll_results",
+      "title": "Get date poll results",
+      "description": "Return each proposed slot of a date poll with its vote count and the usernames who voted for it.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Poll event id."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "confirm_date_poll",
+      "title": "Confirm a date poll",
+      "description": "Pick the winning slot of a date poll: converts the poll into a confirmed event on that slot and returns the attendee conflict report for the confirmed window.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "date_option_id": {
+            "type": "integer",
+            "description": "Winning date option id to confirm."
+          }
+        },
+        "required": [
+          "date_option_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "get_availability",
+      "title": "Get users availability",
+      "description": "Return each user's busy and free time blocks within a window. Only time ranges are returned, never event titles or details.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "usernames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Usernames to compute availability for."
+          },
+          "start": {
+            "type": "string",
+            "description": "Window start (RFC3339)."
+          },
+          "end": {
+            "type": "string",
+            "description": "Window end (RFC3339)."
+          }
+        },
+        "required": [
+          "usernames",
+          "start",
+          "end"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "suggest_meeting_time",
+      "title": "Suggest a meeting time",
+      "description": "Suggest candidate slots of at least duration_minutes where all attendees are free within a window. Optional constraints keyword 'mornings' or 'afternoons' restricts candidate start times.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "attendees": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Usernames who must all be free."
+          },
+          "duration_minutes": {
+            "type": "integer",
+            "description": "Required meeting duration in minutes."
+          },
+          "window_start": {
+            "type": "string",
+            "description": "Earliest acceptable start (RFC3339)."
+          },
+          "window_end": {
+            "type": "string",
+            "description": "Latest acceptable end (RFC3339)."
+          },
+          "constraints": {
+            "type": "string",
+            "description": "Optional free-text constraint; 'mornings' (before 12:00) or 'afternoons' (from 12:00) are honored."
+          }
+        },
+        "required": [
+          "attendees",
+          "duration_minutes",
+          "window_start",
+          "window_end"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_event_attendees",
+      "title": "Get event attendees",
+      "description": "List an event's attendees together with each one's response (ACCEPTED, DECLINED, TENTATIVE or NEEDS_ACTION).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "respond_to_agenda_event",
+      "title": "Respond to an agenda event",
+      "description": "Respond to an event invitation as the current user with ACCEPTED, DECLINED or TENTATIVE. The optional comment is accepted but not persisted (no backend storage for response comments).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id."
+          },
+          "response": {
+            "type": "string",
+            "description": "One of ACCEPTED, DECLINED, TENTATIVE."
+          },
+          "comment": {
+            "type": "string",
+            "description": "Optional free-text comment (not persisted)."
+          }
+        },
+        "required": [
+          "event_id",
+          "response"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "set_event_reminders",
+      "title": "Set event reminders",
+      "description": "Set the current user's reminders on an event. Each reminder is a '<number> <MINUTE|HOUR|DAY|WEEK>' string (e.g. '30 MINUTE').",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id."
+          },
+          "reminders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Reminders as '<number> <MINUTE|HOUR|DAY|WEEK>' strings. An empty list clears the user's reminders."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "get_event_conference",
+      "title": "Get event conference link",
+      "description": "Return the web-conference (e.g. Jitsi) link attached to an event, if any.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "set_event_conference",
+      "title": "Set event conference link",
+      "description": "Attach a web-conference link to an event (defaults type to 'web'). Passing a blank url removes the conference.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id."
+          },
+          "url": {
+            "type": "string",
+            "description": "Conference URL to attach; blank to remove the existing conference."
+          },
+          "type": {
+            "type": "string",
+            "description": "Optional conference type label (default 'web')."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "search_agenda_events",
+      "title": "Search agenda events",
+      "description": "Keyword search over agenda events the current user can access, optionally restricted to a space and post-filtered by a start/end date range.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search keywords (matched against event title/description)."
+          },
+          "start": {
+            "type": "string",
+            "description": "Optional lower bound (RFC3339); events ending before this are excluded."
+          },
+          "end": {
+            "type": "string",
+            "description": "Optional upper bound (RFC3339); events starting after this are excluded."
+          },
+          "space_id": {
+            "type": "integer",
+            "description": "Optional space id to restrict the search."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
     }
   ]
 }

--- a/agenda-services/src/main/resources/ai-tool-definitions.json
+++ b/agenda-services/src/main/resources/ai-tool-definitions.json
@@ -1,0 +1,308 @@
+{
+  "tools": [
+    {
+      "name": "get_agenda_events",
+      "title": "Get agenda events",
+      "description": "Retrieve agenda events for the current user, optionally filtered by RFC3339 start/end, space, and limit.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "space_id": {
+            "type": "integer",
+            "description": "Space id to filter by. If omitted no space filter is applied."
+          },
+          "start": {
+            "type": "string",
+            "description": "RFC3339 datetime string."
+          },
+          "end": {
+            "type": "string",
+            "description": "RFC3339 datetime string."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Max number of events to return."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_agenda_event_by_id",
+      "title": "Get agenda event",
+      "description": "Fetch a single agenda event by its id.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "create_agenda_event",
+      "title": "Create an agenda event",
+      "description": "Create a new agenda event in a space calendar / agenda.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "space_id": {
+            "type": "integer"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Event title."
+          },
+          "description": {
+            "type": "string",
+            "description": "Event description."
+          },
+          "location": {
+            "type": "string",
+            "description": "Event location."
+          },
+          "start": {
+            "type": "string",
+            "description": "Event start datetime in RFC3339 format."
+          },
+          "end": {
+            "type": "string",
+            "description": "Event end datetime in RFC3339 format."
+          },
+          "attendee_usernames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of attendee usernames to invite (the current user is added automatically)."
+          }
+        },
+        "required": [
+          "space_id",
+          "summary",
+          "start",
+          "end"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "update_agenda_event",
+      "title": "Update an agenda event",
+      "description": "Patch / update an agenda event (only provided optional fields are updated).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer"
+          },
+          "summary": {
+            "type": "string",
+            "description": "New event summary."
+          },
+          "description": {
+            "type": "string",
+            "description": "New event description."
+          },
+          "location": {
+            "type": "string",
+            "description": "New event location."
+          },
+          "start": {
+            "type": "string",
+            "description": "New event start datetime (RFC3339)."
+          },
+          "end": {
+            "type": "string",
+            "description": "New event end datetime (RFC3339)."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "delete_agenda_event",
+      "title": "Delete an agenda event",
+      "description": "Delete an agenda event by its id.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id (mandatory, must be non-zero)."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "accept_agenda_event_invitation",
+      "title": "Accept an agenda event invitation",
+      "description": "Accept an agenda event invitation by the current user.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id (mandatory, must be non-zero)."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "decline_agenda_event_invitation",
+      "title": "Decline an agenda event invitation",
+      "description": "Decline an agenda event invitation by the current user.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id (mandatory, must be non-zero)."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "cancel_agenda_event",
+      "title": "Cancel an agenda event",
+      "description": "Cancel an agenda event by the current user",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "description": "Event id (mandatory, must be non-zero)."
+          }
+        },
+        "required": [
+          "event_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "invite_space_to_agenda_event",
+      "title": "Invite space members to an agenda event",
+      "description": "Invite space members to an agenda event",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer"
+          },
+          "space_id": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_id",
+          "space_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "invite_users_to_agenda_event",
+      "title": "Invite users to an agenda event",
+      "description": "Invite users to an agenda event",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "integer"
+          },
+          "attendee_usernames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of attendee usernames to invite (the current user is added automatically)."
+          }
+        },
+        "required": [
+          "event_id",
+          "attendee_usernames"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    }
+  ]
+}

--- a/agenda-services/src/main/resources/ai-tool-definitions.json
+++ b/agenda-services/src/main/resources/ai-tool-definitions.json
@@ -57,12 +57,17 @@
     {
       "name": "create_agenda_event",
       "title": "Create an agenda event",
-      "description": "Create a new agenda event in a space calendar / agenda.",
+      "description": "Create a new agenda event in a space calendar. Every event MUST belong to a space: provide either space_id or the space name via 'space'. If the user didn't say which space, ASK them (or list the spaces they belong to) instead of calling without one.",
       "input_schema": {
         "type": "object",
         "properties": {
           "space_id": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Space id where the event is created. Optional if 'space' (a space name) is given; one of the two is required."
+          },
+          "space": {
+            "type": "string",
+            "description": "Space name (display or pretty name) to resolve to a space, e.g. 'EVA Space'. Used when space_id isn't known. Must be a space the user belongs to."
           },
           "summary": {
             "type": "string",
@@ -113,7 +118,6 @@
           }
         },
         "required": [
-          "space_id",
           "summary",
           "start",
           "end"
@@ -355,13 +359,17 @@
     {
       "name": "create_date_poll",
       "title": "Create a date poll",
-      "description": "Create a date poll: a tentative event with several proposed time slots that attendees can vote on to pick a final date.",
+      "description": "Create a date poll: a tentative event with several proposed time slots that attendees can vote on to pick a final date. Every poll MUST belong to a space: provide either space_id or the space name via 'space'. If the user didn't say which space, ASK them (or list their spaces) instead of calling without one.",
       "input_schema": {
         "type": "object",
         "properties": {
           "space_id": {
             "type": "integer",
-            "description": "Space id where the poll (event) is created."
+            "description": "Space id where the poll (event) is created. Optional if 'space' (a space name) is given; one of the two is required."
+          },
+          "space": {
+            "type": "string",
+            "description": "Space name (display or pretty name) to resolve to a space, e.g. 'EVA Space'. Used when space_id isn't known. Must be a space the user belongs to."
           },
           "title": {
             "type": "string",
@@ -391,7 +399,6 @@
           }
         },
         "required": [
-          "space_id",
           "title",
           "proposed_slots"
         ]

--- a/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.agenda.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.exoplatform.agenda.constant.EventAttendeeResponse;
+import org.exoplatform.agenda.mcp.model.AgendaEventCollectionModel;
+import org.exoplatform.agenda.model.Event;
+import org.exoplatform.agenda.service.AgendaCalendarService;
+import org.exoplatform.agenda.service.AgendaEventAttendeeService;
+import org.exoplatform.agenda.service.AgendaEventConferenceService;
+import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.agenda.service.AgendaUserSettingsService;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.profileproperty.ProfilePropertyService;
+
+import io.meeds.portal.permlink.service.PermanentLinkService;
+import io.meeds.social.translation.service.TranslationService;
+
+class AgendaEventMcpToolTest {
+
+  private static final String                USERNAME         = "testuser1";
+
+  private static final long                  USER_IDENTITY_ID = 5L;
+
+  private static final long                  EVENT_ID         = 42L;
+
+  private static final long                  SPACE_ID         = 7L;
+
+  private AgendaCalendarService              agendaCalendarService;
+
+  private AgendaEventService                 agendaEventService;
+
+  private AgendaEventConferenceService       agendaEventConferenceService;
+
+  private AgendaEventAttendeeService         agendaEventAttendeeService;
+
+  private AgendaUserSettingsService          agendaUserSettingsService;
+
+  private UserPortalConfigService            portalConfigService;
+
+  private ProfilePropertyService             profilePropertyService;
+
+  private PermanentLinkService               permanentLinkService;
+
+  private TranslationService                 translationService;
+
+  private IdentityManager                    identityManager;
+
+  private org.exoplatform.social.core.space.spi.SpaceService spaceService;
+
+  private UserACL                            userAcl;
+
+  private AgendaEventMcpTool                 tool;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    agendaCalendarService = Mockito.mock(AgendaCalendarService.class);
+    agendaEventService = Mockito.mock(AgendaEventService.class);
+    agendaEventConferenceService = Mockito.mock(AgendaEventConferenceService.class);
+    agendaEventAttendeeService = Mockito.mock(AgendaEventAttendeeService.class);
+    agendaUserSettingsService = Mockito.mock(AgendaUserSettingsService.class);
+    portalConfigService = Mockito.mock(UserPortalConfigService.class);
+    profilePropertyService = Mockito.mock(ProfilePropertyService.class);
+    permanentLinkService = Mockito.mock(PermanentLinkService.class);
+    translationService = Mockito.mock(TranslationService.class);
+    identityManager = Mockito.mock(IdentityManager.class);
+    spaceService = Mockito.mock(org.exoplatform.social.core.space.spi.SpaceService.class);
+    userAcl = Mockito.mock(UserACL.class);
+
+    Identity currentUser = Mockito.mock(Identity.class);
+    when(currentUser.getIdentityId()).thenReturn(USER_IDENTITY_ID);
+    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(currentUser);
+
+    org.exoplatform.services.security.Identity aclIdentity =
+                                                           Mockito.mock(org.exoplatform.services.security.Identity.class);
+
+    tool = new AgendaEventMcpTool(agendaCalendarService,
+                                  agendaEventService,
+                                  agendaEventConferenceService,
+                                  agendaEventAttendeeService,
+                                  agendaUserSettingsService,
+                                  portalConfigService,
+                                  profilePropertyService,
+                                  permanentLinkService,
+                                  translationService,
+                                  identityManager,
+                                  spaceService,
+                                  userAcl) {
+      @Override
+      public String getCurrentUserName() {
+        return USERNAME;
+      }
+
+      @Override
+      public org.exoplatform.services.security.Identity getCurrentUserAclIdentity() {
+        return aclIdentity;
+      }
+
+      @Override
+      public Locale getCurrentUserLocale() {
+        return Locale.ENGLISH;
+      }
+    };
+  }
+
+  // --- get_agenda_events ---------------------------------------------------
+
+  @Test
+  void getAgendaEventsReturnsEmptyCollection() throws Exception {
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(Collections.emptyList());
+
+    AgendaEventCollectionModel model = tool.getAgendaEvents(null, null, null, null);
+
+    assertNotNull(model);
+    assertEquals(0, model.getEvents().size());
+    // a default limit is applied when no end date/limit is provided
+    assertEquals(10, model.getUsedLimit());
+  }
+
+  // --- get_agenda_event_by_id ----------------------------------------------
+
+  @Test
+  void getAgendaEventByIdNotFoundFails() throws Exception {
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class, () -> tool.getAgendaEventById(EVENT_ID));
+  }
+
+  // --- create_agenda_event -------------------------------------------------
+
+  @Test
+  void createAgendaEventWithoutSpaceIdFails() throws Exception {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.createAgendaEvent(null, "summary", null, null, null, null, null));
+  }
+
+  @Test
+  void createAgendaEventWithoutPermissionFails() throws Exception {
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class,
+                 () -> tool.createAgendaEvent(SPACE_ID, "summary", null, null, null, null, null));
+  }
+
+  // --- update_agenda_event -------------------------------------------------
+
+  @Test
+  void updateAgendaEventWithoutEventIdFails() throws Exception {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.updateAgendaEvent(null, "summary", null, null, null, null));
+  }
+
+  @Test
+  void updateAgendaEventWithoutPermissionFails() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class,
+                 () -> tool.updateAgendaEvent(EVENT_ID, "summary", null, null, null, null));
+  }
+
+  // --- delete_agenda_event -------------------------------------------------
+
+  @Test
+  void deleteAgendaEventWithoutEventIdFails() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> tool.deleteAgendaEvent(null));
+  }
+
+  @Test
+  void deleteAgendaEventWithoutPermissionFails() throws Exception {
+    when(userAcl.hasDeletePermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class, () -> tool.deleteAgendaEvent(EVENT_ID));
+    verify(agendaEventService, never()).deleteEventById(anyLong(), anyLong());
+  }
+
+  @Test
+  void deleteAgendaEventSucceeds() throws Exception {
+    when(userAcl.hasDeletePermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    tool.deleteAgendaEvent(EVENT_ID);
+    verify(agendaEventService, times(1)).deleteEventById(EVENT_ID, USER_IDENTITY_ID);
+  }
+
+  // --- accept / decline / cancel -------------------------------------------
+
+  @Test
+  void acceptAgendaEventInvitationWithoutPermissionFails() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class, () -> tool.acceptAgendaEventInvitation(EVENT_ID));
+  }
+
+  @Test
+  void acceptAgendaEventInvitationSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    tool.acceptAgendaEventInvitation(EVENT_ID);
+    verify(agendaEventAttendeeService, times(1)).sendEventResponse(EVENT_ID,
+                                                                   USER_IDENTITY_ID,
+                                                                   EventAttendeeResponse.ACCEPTED);
+  }
+
+  @Test
+  void declineAgendaEventInvitationSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    tool.declineAgendaEventInvitation(EVENT_ID);
+    verify(agendaEventAttendeeService, times(1)).sendEventResponse(EVENT_ID,
+                                                                   USER_IDENTITY_ID,
+                                                                   EventAttendeeResponse.DECLINED);
+  }
+
+  @Test
+  void cancelAgendaEventDelegatesToDecline() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    tool.cancelAgendaEvent(EVENT_ID);
+    verify(agendaEventAttendeeService, times(1)).sendEventResponse(EVENT_ID,
+                                                                   USER_IDENTITY_ID,
+                                                                   EventAttendeeResponse.DECLINED);
+  }
+
+  // --- invite_users / invite_space -----------------------------------------
+
+  @Test
+  void inviteUsersToAgendaEventWithoutAttendeesFails() throws Exception {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.inviteUsersToAgendaEvent(EVENT_ID, Collections.emptyList()));
+  }
+
+  @Test
+  void inviteUsersToAgendaEventWithoutPermissionFails() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class,
+                 () -> tool.inviteUsersToAgendaEvent(EVENT_ID, List.of("john")));
+  }
+
+  @Test
+  void inviteSpaceToAgendaEventWithoutSpaceIdFails() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> tool.inviteSpaceToAgendaEvent(EVENT_ID, null));
+  }
+
+  @Test
+  void inviteSpaceToAgendaEventWithoutPermissionFails() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class, () -> tool.inviteSpaceToAgendaEvent(EVENT_ID, SPACE_ID));
+  }
+
+  @SuppressWarnings("unused")
+  private Event mockEvent() {
+    return Mockito.mock(Event.class);
+  }
+
+}

--- a/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
@@ -337,6 +337,35 @@ class AgendaEventMcpToolTest {
   }
 
   @Test
+  void createDatePollResolvesSpaceByName() throws Exception {
+    // A date poll given only a space NAME (space_id == null) must build its event on the RESOLVED space id, not on the
+    // raw null spaceId. Pre-fix the event was built with getSpaceCalendarId(spaceId) which auto-unboxed the null Long to
+    // an NPE; post-fix it uses getSpaceCalendarId(resolvedSpaceId == SPACE_ID). We prove the resolved id flowed through
+    // by leaving getSpaceById(SPACE_ID) unstubbed: post-fix that yields a controlled ObjectNotFoundException on id 7
+    // (NOT an NPE), whereas the pre-fix code throws NPE here.
+    org.exoplatform.social.core.space.model.Space space = Mockito.mock(org.exoplatform.social.core.space.model.Space.class);
+    when(space.getSpaceId()).thenReturn(SPACE_ID);
+    when(spaceService.getSpaceByPrettyName("EVA Space")).thenReturn(space);
+    when(spaceService.isMember(space, USERNAME)).thenReturn(true);
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    ObjectNotFoundException ex =
+                              assertThrows(ObjectNotFoundException.class,
+                                           () -> tool.createDatePoll(null,
+                                                                     "poll",
+                                                                     List.of("2026-07-20T14:00:00Z|2026-07-20T15:00:00Z"),
+                                                                     null,
+                                                                     null,
+                                                                     false,
+                                                                     "EVA Space"));
+    // The resolved space id (7) reached getSpaceCalendarId -> getSpaceById, proving no NPE and correct resolution.
+    assertTrue(ex.getMessage().contains(String.valueOf(SPACE_ID)));
+    verify(spaceService).getSpaceById(SPACE_ID);
+  }
+
+  @Test
   void createAgendaEventWithoutSpaceOrNameGivesGuidance() {
     IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                  () -> tool.createAgendaEvent(null, "summary", null, null, "2026-07-20T14:00:00Z", "2026-07-20T15:00:00Z",

--- a/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
@@ -72,6 +72,10 @@ class AgendaEventMcpToolTest {
 
   private AgendaEventAttendeeService         agendaEventAttendeeService;
 
+  private org.exoplatform.agenda.service.AgendaEventDatePollService agendaEventDatePollService;
+
+  private org.exoplatform.agenda.service.AgendaEventReminderService agendaEventReminderService;
+
   private AgendaUserSettingsService          agendaUserSettingsService;
 
   private UserPortalConfigService            portalConfigService;
@@ -96,6 +100,8 @@ class AgendaEventMcpToolTest {
     agendaEventService = Mockito.mock(AgendaEventService.class);
     agendaEventConferenceService = Mockito.mock(AgendaEventConferenceService.class);
     agendaEventAttendeeService = Mockito.mock(AgendaEventAttendeeService.class);
+    agendaEventDatePollService = Mockito.mock(org.exoplatform.agenda.service.AgendaEventDatePollService.class);
+    agendaEventReminderService = Mockito.mock(org.exoplatform.agenda.service.AgendaEventReminderService.class);
     agendaUserSettingsService = Mockito.mock(AgendaUserSettingsService.class);
     portalConfigService = Mockito.mock(UserPortalConfigService.class);
     profilePropertyService = Mockito.mock(ProfilePropertyService.class);
@@ -116,6 +122,8 @@ class AgendaEventMcpToolTest {
                                   agendaEventService,
                                   agendaEventConferenceService,
                                   agendaEventAttendeeService,
+                                  agendaEventDatePollService,
+                                  agendaEventReminderService,
                                   agendaUserSettingsService,
                                   portalConfigService,
                                   profilePropertyService,
@@ -168,7 +176,7 @@ class AgendaEventMcpToolTest {
   @Test
   void createAgendaEventWithoutSpaceIdFails() throws Exception {
     assertThrows(IllegalArgumentException.class,
-                 () -> tool.createAgendaEvent(null, "summary", null, null, null, null, null));
+                 () -> tool.createAgendaEvent(null, "summary", null, null, null, null, null, null, null, null, null, null));
   }
 
   @Test
@@ -178,7 +186,7 @@ class AgendaEventMcpToolTest {
                                any(),
                                any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
     assertThrows(IllegalAccessException.class,
-                 () -> tool.createAgendaEvent(SPACE_ID, "summary", null, null, null, null, null));
+                 () -> tool.createAgendaEvent(SPACE_ID, "summary", null, null, null, null, null, null, null, null, null, null));
   }
 
   // --- update_agenda_event -------------------------------------------------
@@ -186,14 +194,14 @@ class AgendaEventMcpToolTest {
   @Test
   void updateAgendaEventWithoutEventIdFails() throws Exception {
     assertThrows(IllegalArgumentException.class,
-                 () -> tool.updateAgendaEvent(null, "summary", null, null, null, null));
+                 () -> tool.updateAgendaEvent(null, "summary", null, null, null, null, null, null, null, null, null));
   }
 
   @Test
   void updateAgendaEventWithoutPermissionFails() throws Exception {
     when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
     assertThrows(IllegalAccessException.class,
-                 () -> tool.updateAgendaEvent(EVENT_ID, "summary", null, null, null, null));
+                 () -> tool.updateAgendaEvent(EVENT_ID, "summary", null, null, null, null, null, null, null, null, null));
   }
 
   // --- delete_agenda_event -------------------------------------------------
@@ -237,7 +245,7 @@ class AgendaEventMcpToolTest {
   @Test
   void declineAgendaEventInvitationSucceeds() throws Exception {
     when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
-    tool.declineAgendaEventInvitation(EVENT_ID);
+    tool.declineAgendaEventInvitation(EVENT_ID, null);
     verify(agendaEventAttendeeService, times(1)).sendEventResponse(EVENT_ID,
                                                                    USER_IDENTITY_ID,
                                                                    EventAttendeeResponse.DECLINED);
@@ -246,7 +254,7 @@ class AgendaEventMcpToolTest {
   @Test
   void cancelAgendaEventDelegatesToDecline() throws Exception {
     when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
-    tool.cancelAgendaEvent(EVENT_ID);
+    tool.cancelAgendaEvent(EVENT_ID, null);
     verify(agendaEventAttendeeService, times(1)).sendEventResponse(EVENT_ID,
                                                                    USER_IDENTITY_ID,
                                                                    EventAttendeeResponse.DECLINED);
@@ -276,6 +284,56 @@ class AgendaEventMcpToolTest {
   void inviteSpaceToAgendaEventWithoutPermissionFails() throws Exception {
     when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
     assertThrows(IllegalAccessException.class, () -> tool.inviteSpaceToAgendaEvent(EVENT_ID, SPACE_ID));
+  }
+
+  // --- new scheduling tools ------------------------------------------------
+
+  @Test
+  void createDatePollWithoutSlotsFails() throws Exception {
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.createDatePoll(SPACE_ID, "poll", Collections.emptyList(), null, null, false));
+  }
+
+  @Test
+  void getDatePollResultsWithoutEventIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.getDatePollResults(0L));
+  }
+
+  @Test
+  void confirmDatePollWithoutOptionIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.confirmDatePoll(null));
+  }
+
+  @Test
+  void getAvailabilityWithoutUsernamesFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.getAvailability(Collections.emptyList(), "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"));
+  }
+
+  @Test
+  void suggestMeetingTimeWithoutDurationFails() {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.suggestMeetingTime(List.of("john"), 0, "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", null));
+  }
+
+  @Test
+  void respondToAgendaEventWithInvalidResponseFails() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    assertThrows(IllegalArgumentException.class, () -> tool.respondToAgendaEvent(EVENT_ID, "MAYBE", null));
+  }
+
+  @Test
+  void setEventConferenceWithoutPermissionFails() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class, () -> tool.setEventConference(EVENT_ID, "https://meet.example/x", null));
+  }
+
+  @Test
+  void searchAgendaEventsWithoutQueryFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.searchAgendaEvents(" ", null, null, null));
   }
 
   @SuppressWarnings("unused")

--- a/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
@@ -19,6 +19,7 @@ package org.exoplatform.agenda.mcp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -176,7 +177,7 @@ class AgendaEventMcpToolTest {
   @Test
   void createAgendaEventWithoutSpaceIdFails() throws Exception {
     assertThrows(IllegalArgumentException.class,
-                 () -> tool.createAgendaEvent(null, "summary", null, null, null, null, null, null, null, null, null, null));
+                 () -> tool.createAgendaEvent(null, "summary", null, null, null, null, null, null, null, null, null, null, null));
   }
 
   @Test
@@ -186,7 +187,7 @@ class AgendaEventMcpToolTest {
                                any(),
                                any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
     assertThrows(IllegalAccessException.class,
-                 () -> tool.createAgendaEvent(SPACE_ID, "summary", null, null, null, null, null, null, null, null, null, null));
+                 () -> tool.createAgendaEvent(SPACE_ID, "summary", null, null, null, null, null, null, null, null, null, null, null));
   }
 
   // --- update_agenda_event -------------------------------------------------
@@ -315,7 +316,32 @@ class AgendaEventMcpToolTest {
                                any(),
                                any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
     assertThrows(IllegalArgumentException.class,
-                 () -> tool.createDatePoll(SPACE_ID, "poll", Collections.emptyList(), null, null, false));
+                 () -> tool.createDatePoll(SPACE_ID, "poll", Collections.emptyList(), null, null, false, null));
+  }
+
+  @Test
+  void createAgendaEventResolvesSpaceByName() throws Exception {
+    // A space name (no space_id) must resolve to the space; here permission is denied on the resolved id, which proves
+    // the name was resolved to SPACE_ID and the flow proceeded to the space create-permission check.
+    org.exoplatform.social.core.space.model.Space space = Mockito.mock(org.exoplatform.social.core.space.model.Space.class);
+    when(space.getSpaceId()).thenReturn(SPACE_ID);
+    when(spaceService.getSpaceByPrettyName("EVA Space")).thenReturn(space);
+    when(spaceService.isMember(space, USERNAME)).thenReturn(true);
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class,
+                 () -> tool.createAgendaEvent(null, "summary", null, null, "2026-07-20T14:00:00Z", "2026-07-20T15:00:00Z",
+                                              null, null, null, null, null, null, "EVA Space"));
+  }
+
+  @Test
+  void createAgendaEventWithoutSpaceOrNameGivesGuidance() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                 () -> tool.createAgendaEvent(null, "summary", null, null, "2026-07-20T14:00:00Z", "2026-07-20T15:00:00Z",
+                                              null, null, null, null, null, null, null));
+    assertTrue(ex.getMessage().toLowerCase().contains("space"));
   }
 
   @Test

--- a/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
@@ -260,6 +260,26 @@ class AgendaEventMcpToolTest {
                                                                    EventAttendeeResponse.DECLINED);
   }
 
+  @Test
+  void cancelSingleOccurrenceMaterializesExceptionalAndCancelsIt() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    Event exceptional = Mockito.mock(Event.class);
+    when(exceptional.getId()).thenReturn(99L);
+    when(agendaEventService.saveEventExceptionalOccurrence(eq(EVENT_ID), any())).thenReturn(exceptional);
+
+    tool.cancelAgendaEvent(EVENT_ID, "2026-07-20T09:00:00Z");
+
+    // Cancelling one occurrence must NOT decline (which used to drop this-and-future)
+    verify(agendaEventAttendeeService, never()).sendUpcomingEventResponse(anyLong(), any(), anyLong(), any());
+    verify(agendaEventService, times(1)).saveEventExceptionalOccurrence(eq(EVENT_ID), any());
+    verify(agendaEventService, times(1)).updateEventFields(eq(99L),
+                                                           eq(java.util.Collections.singletonMap("status",
+                                                                                                 java.util.Collections.singletonList("CANCELLED"))),
+                                                           eq(false),
+                                                           eq(false),
+                                                           eq(USER_IDENTITY_ID));
+  }
+
   // --- invite_users / invite_space -----------------------------------------
 
   @Test

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -844,6 +844,35 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
   }
 
   @Test
+  public void testBusyEventsAreOnlyAcceptedOnes() throws Exception { // NOSONAR
+    // Backs the MCP free/busy primitive (get_availability / suggest_meeting_time / conflicts): a user is busy only for
+    // events they ACCEPTED. An invited-but-not-yet-accepted event must NOT make them busy; accepting flips it to busy.
+    ZonedDateTime start = getDate().withNano(0);
+    Event event = newEventInstance(start, start.plusHours(1), false);
+    event.setRecurrence(null); // single (non-recurring) event
+    event = createEvent(event.clone(),
+                        Long.parseLong(testuser1Identity.getId()),
+                        testuser1Identity,
+                        testuser2Identity);
+
+    long user2 = Long.parseLong(testuser2Identity.getId());
+    EventFilter acceptedFilter = new EventFilter(user2,
+                                                 null,
+                                                 Collections.singletonList(EventAttendeeResponse.ACCEPTED),
+                                                 start.minusHours(1),
+                                                 start.plusHours(2),
+                                                 10);
+    // testuser2 was only invited -> NEEDS_ACTION -> not busy
+    List<Event> before = agendaEventService.getEvents(acceptedFilter.clone(), ZoneOffset.UTC, user2);
+    assertTrue("an invited-but-not-accepted event must NOT count as busy", before.isEmpty());
+
+    // testuser2 accepts -> now busy
+    agendaEventAttendeeService.sendEventResponse(event.getId(), user2, EventAttendeeResponse.ACCEPTED);
+    List<Event> after = agendaEventService.getEvents(acceptedFilter.clone(), ZoneOffset.UTC, user2);
+    assertEquals("an accepted event must count as busy", 1, after.size());
+  }
+
+  @Test
   public void testCancelSingleOccurrenceKeepsSurroundingOccurrences() throws Exception { // NOSONAR
     // Regression for EXO-88461: cancelling ONE occurrence of a recurring series must remove only that date and keep
     // every occurrence before AND after it (the MCP cancel_agenda_event(occurrence_id) bug used to drop this-and-future).

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaEventServiceTest.java
@@ -844,6 +844,68 @@ public class AgendaEventServiceTest extends BaseAgendaEventTest {
   }
 
   @Test
+  public void testCancelSingleOccurrenceKeepsSurroundingOccurrences() throws Exception { // NOSONAR
+    // Regression for EXO-88461: cancelling ONE occurrence of a recurring series must remove only that date and keep
+    // every occurrence before AND after it (the MCP cancel_agenda_event(occurrence_id) bug used to drop this-and-future).
+    ZoneId timeZone = ZoneOffset.UTC;
+    ZonedDateTime start = ZonedDateTime.of(2022, 3, 7, 10, 0, 0, 0, timeZone);
+    Event event = newEventInstance(start, start.plusHours(1), false);
+    event.setTimeZoneId(timeZone);
+    // Weekly, 6 occurrences
+    EventRecurrence recurrence = new EventRecurrence(0,
+                                                     null,
+                                                     6,
+                                                     EventRecurrenceType.WEEKLY,
+                                                     EventRecurrenceFrequency.WEEKLY,
+                                                     1,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null,
+                                                     null);
+    event.setRecurrence(recurrence);
+    event = createEvent(event, Long.parseLong(testuser1Identity.getId()), testuser1Identity, testuser2Identity);
+
+    ZonedDateTime periodStart = start.minusDays(1);
+    ZonedDateTime periodEnd = start.plusWeeks(6).plusDays(1);
+    List<Event> before = agendaEventService.getEventOccurrencesInPeriod(event, periodStart, periodEnd, timeZone, 0);
+    assertEquals("expected 6 weekly occurrences before cancellation", 6, before.size());
+    LocalDate secondDate = before.get(1).getStart().withZoneSameInstant(ZoneOffset.UTC).toLocalDate();
+    LocalDate thirdDate = before.get(2).getStart().withZoneSameInstant(ZoneOffset.UTC).toLocalDate();
+    LocalDate fourthDate = before.get(3).getStart().withZoneSameInstant(ZoneOffset.UTC).toLocalDate();
+
+    // Cancel ONLY the 3rd occurrence exactly as the MCP tool does: materialize the exceptional occurrence, then
+    // set its status to CANCELLED.
+    Event exceptional = agendaEventService.saveEventExceptionalOccurrence(event.getId(),
+                                                                          before.get(2).getOccurrence().getId());
+    agendaEventService.updateEventFields(exceptional.getId(),
+                                         Collections.singletonMap("status",
+                                                                  Collections.singletonList(EventStatus.CANCELLED.name())),
+                                         false,
+                                         false,
+                                         Long.parseLong(testuser1Identity.getId()));
+
+    // The cancelled exceptional occurrence must be persisted as CANCELLED (so it is hidden from listings)
+    assertEquals(EventStatus.CANCELLED, agendaEventService.getEventById(exceptional.getId()).getStatus());
+
+    List<Event> after = agendaEventService.getEventOccurrencesInPeriod(event, periodStart, periodEnd, timeZone, 0);
+    List<LocalDate> remainingDates = after.stream()
+                                          .map(o -> o.getStart().withZoneSameInstant(ZoneOffset.UTC).toLocalDate())
+                                          .toList();
+    assertEquals("expected 5 occurrences after cancelling one", 5, after.size());
+    assertFalse("cancelled 3rd occurrence must be gone", remainingDates.contains(thirdDate));
+    // The occurrences surrounding the cancelled one (before AND after it) must still exist
+    assertTrue("occurrence before the cancelled date must remain", remainingDates.contains(secondDate));
+    assertTrue("occurrence after the cancelled date must remain", remainingDates.contains(fourthDate));
+  }
+
+  @Test
   public void testGetParentRecurrentEvents() throws Exception { // NOSONAR
     ZonedDateTime start = getDate().withNano(0);
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <!-- 3rd party libraries versions -->
     <org.exoplatform.commons-exo.version>7.3.x-ai-contribution-SNAPSHOT</org.exoplatform.commons-exo.version>
+    <io.meeds.mcp-server.version>7.3.x-ai-contribution-SNAPSHOT</io.meeds.mcp-server.version>
 
     <!-- ical4j dependencies -->
     <org.mnode.ical4j.version>3.2.19</org.mnode.ical4j.version>
@@ -44,6 +45,15 @@
         <groupId>org.exoplatform.commons-exo</groupId>
         <artifactId>commons-exo</artifactId>
         <version>${org.exoplatform.commons-exo.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Import versions from MCP Server project (used by the agenda MCP tools exposed to the AI agent) -->
+      <dependency>
+        <groupId>io.meeds.mcp-server</groupId>
+        <artifactId>mcp-server</artifactId>
+        <version>${io.meeds.mcp-server.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What
Brings the agenda MCP tools into the open agenda add-on and expands them into a real scheduling toolset — **22 tools total**.

- **Relocated from the enterprise distribution** (EXO-86697): the 10 event-lifecycle tools (`get_agenda_events`, `get_agenda_event_by_id`, `create/update/delete/cancel_agenda_event`, `accept/decline_agenda_event_invitation`, `invite_users/space_to_agenda_event`).
- **New scheduling tools** (EXO-88461): `create_date_poll`/`vote_date_poll`/`get_date_poll_results`/`confirm_date_poll`, `get_availability`, `suggest_meeting_time`, `get_event_attendees`, `respond_to_agenda_event` (incl. TENTATIVE), `set_event_reminders`, `get/set_event_conference`, `search_agenda_events`; plus **RRULE recurrence** + `occurrence_id`, and a **conflict-aware** create/update (`conflicts` block + `fail_on_conflict`).

## Key behaviors
- **Single-occurrence cancel**: `cancel_agenda_event(occurrence_id)` cancels only that date (exceptional-occurrence + CANCELLED), keeping the rest of the series — not this-and-following.
- **Space required, resolvable by name**: create tools accept a space id **or name** (events must belong to a space; no personal calendar in eXo).
- **Free/busy = ACCEPTED only**: `get_availability`/`suggest_meeting_time`/conflicts count events the user has accepted (+ owned), not mere invitations. (Remote/CalDAV free/busy is not server-queryable today — noted as a follow-up.)
- Writes `require_approval`; acts as the user (ACL-enforced).

## Verification
83 service-level integration tests (real container services, not mocks) all green, **plus** end-to-end live verification through EVA (create in a space by name → cancel one occurrence → "all other weeks kept").

## Dependency / CI
Consumes `mcp-server-tools` (`McpToolPlugin`) at the `*-ai-contribution` line — **CI will be red until that version is published** (same as the other add-on MCP PRs).

Board: EXO-88461 (scheduling) / EXO-86697 (relocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)