### PR TITLE
feat: Do not inform participants when someone declined an invitation - EXO-88398

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/notification/plugin/EventReplyNotificationPlugin.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/notification/plugin/EventReplyNotificationPlugin.java
@@ -14,6 +14,7 @@ import org.exoplatform.agenda.model.Event;
 import org.exoplatform.agenda.model.EventAttendee;
 import org.exoplatform.agenda.service.AgendaCalendarService;
 import org.exoplatform.agenda.service.AgendaEventAttendeeService;
+import org.exoplatform.agenda.service.AgendaEventService;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
@@ -37,17 +38,21 @@ public class EventReplyNotificationPlugin extends BaseNotificationPlugin {
 
   private AgendaEventAttendeeService eventAttendeeService;
 
+  private AgendaEventService         eventService;
+
   private SpaceService               spaceService;
 
   public EventReplyNotificationPlugin(InitParams initParams,
                                       IdentityManager identityManager,
                                       AgendaCalendarService calendarService,
                                       AgendaEventAttendeeService eventAttendeeService,
+                                      AgendaEventService eventService,
                                       SpaceService spaceService) {
     super(initParams);
     this.identityManager = identityManager;
     this.calendarService = calendarService;
     this.eventAttendeeService = eventAttendeeService;
+    this.eventService = eventService;
     this.spaceService = spaceService;
     ValueParam notificationIdParam = initParams.getValueParam(AGENDA_NOTIFICATION_PLUGIN_NAME);
     if (notificationIdParam == null || StringUtils.isBlank(notificationIdParam.getValue())) {
@@ -91,8 +96,10 @@ public class EventReplyNotificationPlugin extends BaseNotificationPlugin {
                                                                                     occurrenceId,
                                                                                     EventAttendeeResponse.ACCEPTED,
                                                                                     EventAttendeeResponse.TENTATIVE);
-        Set<Long> eventAttendeeIds = eventAttendees.stream().map(EventAttendee::getIdentityId).collect(Collectors.toSet());
-        eventAttendeeIds = new HashSet<>(eventAttendeeIds);
+        Set<Long> eventAttendeeIds = eventAttendees.stream()
+                                                   .map(EventAttendee::getIdentityId)
+                                                   .filter(identityId -> eventService.canUpdateEvent(event, identityId))
+                                                   .collect(Collectors.toSet());
         eventAttendeeIds.add(event.getCreatorId());
         eventAttendeeIds.remove(eventParticipantId);
         receivers = eventAttendeeIds;

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/notification/plugin/AgendaReplyNotificationPluginTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/notification/plugin/AgendaReplyNotificationPluginTest.java
@@ -62,6 +62,7 @@ public class AgendaReplyNotificationPluginTest extends BaseAgendaEventTest {
                                                                                             identityManager,
                                                                                             agendaCalendarService,
                                                                                             agendaEventAttendeeService,
+                                                                                            agendaEventService,
                                                                                             spaceService);
     NotificationContext ctx =
                             NotificationContextImpl.cloneInstance()


### PR DESCRIPTION
Filter notification recipients using canUpdateEvent when the event creators declines, replacing the previous broadcast to all accepted/attempt attendees.