### PR TITLE
test: Add missing unit tests for agenda MCP scheduling tools - EXO-88461

### DIFF
--- a/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/mcp/AgendaEventMcpToolTest.java
@@ -18,10 +18,13 @@ package org.exoplatform.agenda.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -38,8 +42,25 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.exoplatform.agenda.constant.EventAttendeeResponse;
+import org.exoplatform.agenda.constant.EventRecurrenceFrequency;
+import org.exoplatform.agenda.constant.EventStatus;
+import org.exoplatform.agenda.constant.ReminderPeriodType;
+import org.exoplatform.agenda.mcp.model.AgendaEventAttendeeModel;
 import org.exoplatform.agenda.mcp.model.AgendaEventCollectionModel;
+import org.exoplatform.agenda.mcp.model.AgendaEventModel;
+import org.exoplatform.agenda.mcp.model.AvailabilityModel;
+import org.exoplatform.agenda.mcp.model.ConferenceModel;
+import org.exoplatform.agenda.mcp.model.DatePollModel;
+import org.exoplatform.agenda.mcp.model.TimeBlockModel;
+import org.exoplatform.agenda.model.AgendaUserSettings;
+import org.exoplatform.agenda.model.Calendar;
 import org.exoplatform.agenda.model.Event;
+import org.exoplatform.agenda.model.EventAttendee;
+import org.exoplatform.agenda.model.EventAttendeeList;
+import org.exoplatform.agenda.model.EventConference;
+import org.exoplatform.agenda.model.EventDateOption;
+import org.exoplatform.agenda.model.EventReminder;
+import org.exoplatform.agenda.model.EventSearchResult;
 import org.exoplatform.agenda.service.AgendaCalendarService;
 import org.exoplatform.agenda.service.AgendaEventAttendeeService;
 import org.exoplatform.agenda.service.AgendaEventConferenceService;
@@ -64,6 +85,16 @@ class AgendaEventMcpToolTest {
   private static final long                  EVENT_ID         = 42L;
 
   private static final long                  SPACE_ID         = 7L;
+
+  private static final long                  CALENDAR_ID      = 500L;
+
+  private static final long                  OWNER_IDENTITY_ID = 900L;
+
+  private static final String                SPACE_PRETTY_NAME = "eva-space";
+
+  private static final ZonedDateTime         START            = ZonedDateTime.of(2026, 7, 20, 9, 0, 0, 0, ZoneOffset.UTC);
+
+  private static final ZonedDateTime         END              = ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC);
 
   private AgendaCalendarService              agendaCalendarService;
 
@@ -95,6 +126,8 @@ class AgendaEventMcpToolTest {
 
   private AgendaEventMcpTool                 tool;
 
+  private Identity                           currentUserIdentityMock;
+
   @BeforeEach
   void setUp() throws Exception {
     agendaCalendarService = Mockito.mock(AgendaCalendarService.class);
@@ -112,12 +145,14 @@ class AgendaEventMcpToolTest {
     spaceService = Mockito.mock(org.exoplatform.social.core.space.spi.SpaceService.class);
     userAcl = Mockito.mock(UserACL.class);
 
-    Identity currentUser = Mockito.mock(Identity.class);
-    when(currentUser.getIdentityId()).thenReturn(USER_IDENTITY_ID);
-    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(currentUser);
+    currentUserIdentityMock = Mockito.mock(Identity.class);
+    when(currentUserIdentityMock.getIdentityId()).thenReturn(USER_IDENTITY_ID);
+    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(currentUserIdentityMock);
 
     org.exoplatform.services.security.Identity aclIdentity =
                                                            Mockito.mock(org.exoplatform.services.security.Identity.class);
+
+    when(agendaUserSettingsService.getAgendaUserSettings(USER_IDENTITY_ID)).thenReturn(new AgendaUserSettings());
 
     tool = new AgendaEventMcpTool(agendaCalendarService,
                                   agendaEventService,
@@ -409,6 +444,667 @@ class AgendaEventMcpToolTest {
   @Test
   void searchAgendaEventsWithoutQueryFails() {
     assertThrows(IllegalArgumentException.class, () -> tool.searchAgendaEvents(" ", null, null, null));
+  }
+
+  // --- test helpers ----------------------------------------------------------
+
+  /** Stubs the space <-> calendar <-> owner-identity chain used by both getSpaceCalendarId and getCalendarSpaceId. */
+  private org.exoplatform.social.core.space.model.Space stubSpaceCalendarChain(long spaceId,
+                                                                               String prettyName,
+                                                                               long ownerIdentityId,
+                                                                               long calendarId) {
+    org.exoplatform.social.core.space.model.Space space = Mockito.mock(org.exoplatform.social.core.space.model.Space.class);
+    when(space.getSpaceId()).thenReturn(spaceId);
+    when(space.getPrettyName()).thenReturn(prettyName);
+    when(space.getDisplayName()).thenReturn(prettyName);
+    when(spaceService.getSpaceById(spaceId)).thenReturn(space);
+    when(spaceService.getSpaceByPrettyName(prettyName)).thenReturn(space);
+
+    Identity ownerIdentity = Mockito.mock(Identity.class);
+    when(ownerIdentity.getIdentityId()).thenReturn(ownerIdentityId);
+    when(ownerIdentity.getRemoteId()).thenReturn(prettyName);
+    when(identityManager.getOrCreateSpaceIdentity(prettyName)).thenReturn(ownerIdentity);
+    when(identityManager.getIdentity(ownerIdentityId)).thenReturn(ownerIdentity);
+
+    Calendar calendar = new Calendar();
+    calendar.setId(calendarId);
+    calendar.setOwnerId(ownerIdentityId);
+    when(agendaCalendarService.getOrCreateCalendarByOwnerId(ownerIdentityId)).thenReturn(calendar);
+    when(agendaCalendarService.getCalendarById(calendarId)).thenReturn(calendar);
+    return space;
+  }
+
+  /** Builds a real Event with creatorId=0 (so toAgendaEventModel's getUserModel short-circuits to null, no UI lookup). */
+  private Event buildEvent(long id, long calendarId, ZonedDateTime start, ZonedDateTime end, EventStatus status) {
+    Event event = new Event();
+    event.setId(id);
+    event.setCalendarId(calendarId);
+    event.setCreatorId(0L);
+    event.setStart(start);
+    event.setEnd(end);
+    event.setStatus(status);
+    event.setSummary("summary");
+    return event;
+  }
+
+  // --- decline / cancel guard clauses -----------------------------------------
+
+  @Test
+  void declineAgendaEventInvitationWithoutEventIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.declineAgendaEventInvitation(null, null));
+  }
+
+  @Test
+  void declineAgendaEventInvitationWithoutPermissionFails() {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class, () -> tool.declineAgendaEventInvitation(EVENT_ID, null));
+  }
+
+  @Test
+  void declineAgendaEventInvitationWithOccurrenceIdSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+
+    tool.declineAgendaEventInvitation(EVENT_ID, "2026-07-20T09:00:00Z");
+
+    verify(agendaEventAttendeeService,
+          times(1)).sendUpcomingEventResponse(eq(EVENT_ID), any(), eq(USER_IDENTITY_ID), eq(EventAttendeeResponse.DECLINED));
+    verify(agendaEventAttendeeService, never()).sendEventResponse(anyLong(), anyLong(), any());
+  }
+
+  @Test
+  void cancelAgendaEventWithoutEventIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.cancelAgendaEvent(null, null));
+  }
+
+  @Test
+  void cancelSingleOccurrenceWithoutEditPermissionFails() {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+    assertThrows(IllegalAccessException.class, () -> tool.cancelAgendaEvent(EVENT_ID, "2026-07-20T09:00:00Z"));
+  }
+
+  // --- create_agenda_event happy paths + conflicts ----------------------------
+
+  @Test
+  void createAgendaEventSucceedsWithRecurrenceCount() throws Exception {
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event created = buildEvent(600L, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.createEvent(any(), any(), any(), any(), any(), any(), anyBoolean(), eq(USER_IDENTITY_ID)))
+                                                                                                                     .thenReturn(created);
+
+    AgendaEventModel model = tool.createAgendaEvent(SPACE_ID,
+                                                    "Kickoff",
+                                                    "desc",
+                                                    "room 1",
+                                                    "2026-07-20T09:00:00Z",
+                                                    "2026-07-20T10:00:00Z",
+                                                    null,
+                                                    "daily",
+                                                    2,
+                                                    null,
+                                                    5,
+                                                    null,
+                                                    null);
+
+    assertNotNull(model);
+    assertTrue(model.getConflicts().isAllAvailable());
+    verify(agendaEventService,
+          times(1)).createEvent(argThat(e -> e.getRecurrence() != null
+                                              && e.getRecurrence().getFrequency() == EventRecurrenceFrequency.DAILY
+                                              && e.getRecurrence().getInterval() == 2
+                                              && e.getRecurrence().getCount() == 5),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                anyBoolean(),
+                                eq(USER_IDENTITY_ID));
+  }
+
+  @Test
+  void createAgendaEventDetectsConflictsAndFailsWhenRequested() throws Exception {
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+
+    Identity busyIdentity = Mockito.mock(Identity.class);
+    when(busyIdentity.getIdentityId()).thenReturn(201L);
+    when(busyIdentity.isUser()).thenReturn(true);
+    when(busyIdentity.getRemoteId()).thenReturn("busy.user");
+    when(identityManager.getOrCreateUserIdentity("busy.user")).thenReturn(busyIdentity);
+    when(identityManager.getIdentity(201L)).thenReturn(busyIdentity);
+    Event busyEvent = buildEvent(700L, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(201L))).thenReturn(List.of(busyEvent));
+
+    Identity silentIdentity = Mockito.mock(Identity.class);
+    when(silentIdentity.getIdentityId()).thenReturn(202L);
+    when(identityManager.getOrCreateUserIdentity("silent.user")).thenReturn(silentIdentity);
+    // identityManager.getIdentity(202L) intentionally left unstubbed -> null -> "unresolved identity" branch
+
+    Identity freeIdentity = Mockito.mock(Identity.class);
+    when(freeIdentity.getIdentityId()).thenReturn(203L);
+    when(freeIdentity.isUser()).thenReturn(true);
+    when(identityManager.getOrCreateUserIdentity("free.user")).thenReturn(freeIdentity);
+    when(identityManager.getIdentity(203L)).thenReturn(freeIdentity);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(203L))).thenReturn(Collections.emptyList());
+
+    IllegalStateException ex =
+                              assertThrows(IllegalStateException.class,
+                                           () -> tool.createAgendaEvent(SPACE_ID,
+                                                                        "Kickoff",
+                                                                        null,
+                                                                        null,
+                                                                        "2026-07-20T09:00:00Z",
+                                                                        "2026-07-20T10:00:00Z",
+                                                                        List.of("busy.user", "silent.user", "free.user"),
+                                                                        null,
+                                                                        null,
+                                                                        null,
+                                                                        null,
+                                                                        true,
+                                                                        null));
+    assertTrue(ex.getMessage().contains("1"));
+    verify(agendaEventService, never()).createEvent(any(), any(), any(), any(), any(), any(), anyBoolean(), anyLong());
+  }
+
+  @Test
+  void createAgendaEventResolvesSpaceByDisplayNameViaMemberSpacesFallback() throws Exception {
+    when(spaceService.getSpaceByPrettyName("Eva Team")).thenReturn(null);
+    org.exoplatform.social.core.space.model.Space memberSpace =
+                                                               Mockito.mock(org.exoplatform.social.core.space.model.Space.class);
+    when(memberSpace.getSpaceId()).thenReturn(SPACE_ID);
+    when(memberSpace.getDisplayName()).thenReturn("Eva Team");
+    when(memberSpace.getPrettyName()).thenReturn("eva-team");
+    @SuppressWarnings("unchecked")
+    org.exoplatform.commons.utils.ListAccess<org.exoplatform.social.core.space.model.Space> memberSpaces =
+                                                                                                          Mockito.mock(org.exoplatform.commons.utils.ListAccess.class);
+    when(memberSpaces.getSize()).thenReturn(1);
+    when(memberSpaces.load(0, 1)).thenReturn(new org.exoplatform.social.core.space.model.Space[] { memberSpace });
+    when(spaceService.getMemberSpaces(USERNAME)).thenReturn(memberSpaces);
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(false);
+
+    assertThrows(IllegalAccessException.class,
+                 () -> tool.createAgendaEvent(null,
+                                              "summary",
+                                              null,
+                                              null,
+                                              "2026-07-20T14:00:00Z",
+                                              "2026-07-20T15:00:00Z",
+                                              null,
+                                              null,
+                                              null,
+                                              null,
+                                              null,
+                                              null,
+                                              "Eva Team"));
+  }
+
+  // --- update_agenda_event happy paths -----------------------------------------
+
+  @Test
+  void updateAgendaEventUpdatesFieldsWithoutRecurrence() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event existing = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(existing);
+
+    AgendaEventModel model =
+                           tool.updateAgendaEvent(EVENT_ID, "New summary", null, null, null, null, null, null, null, null, null);
+
+    assertNotNull(model);
+    assertTrue(model.getConflicts().isAllAvailable());
+    verify(agendaEventService,
+          times(1)).updateEventFields(eq(EVENT_ID),
+                                      eq(Collections.singletonMap("summary", Collections.singletonList("New summary"))),
+                                      eq(false),
+                                      eq(false),
+                                      eq(USER_IDENTITY_ID));
+    verify(agendaEventService, never()).updateEvent(any(), any(), any(), any(), any(), any(), anyBoolean(), anyLong());
+  }
+
+  @Test
+  void updateAgendaEventNotFoundFails() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class,
+                 () -> tool.updateAgendaEvent(EVENT_ID, "x", null, null, null, null, null, null, null, null, null));
+  }
+
+  @Test
+  void updateAgendaEventWithRecurrenceUntilSucceeds() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event existing = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(existing);
+    when(agendaEventService.updateEvent(any(), any(), any(), any(), any(), any(), anyBoolean(), eq(USER_IDENTITY_ID)))
+                                                                                                                     .thenReturn(existing);
+
+    AgendaEventModel model = tool.updateAgendaEvent(EVENT_ID,
+                                                    "Weekly sync",
+                                                    "desc",
+                                                    "room",
+                                                    null,
+                                                    null,
+                                                    "weekly",
+                                                    null,
+                                                    "2026-09-01T00:00:00Z",
+                                                    null,
+                                                    null);
+
+    assertNotNull(model);
+    verify(agendaEventService,
+          times(1)).updateEvent(argThat(e -> e.getRecurrence() != null
+                                             && e.getRecurrence().getFrequency() == EventRecurrenceFrequency.WEEKLY
+                                             && e.getRecurrence().getUntil() != null),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                eq(false),
+                                eq(USER_IDENTITY_ID));
+    verify(agendaEventService, never()).updateEventFields(anyLong(), any(), anyBoolean(), anyBoolean(), anyLong());
+  }
+
+  // --- invite_users / invite_space happy paths --------------------------------
+
+  @Test
+  void inviteUsersToAgendaEventSucceeds() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(agendaEventAttendeeService.getEventAttendees(EVENT_ID)).thenReturn(new EventAttendeeList(Collections.emptyList()));
+    Identity johnIdentity = Mockito.mock(Identity.class);
+    when(johnIdentity.getIdentityId()).thenReturn(300L);
+    when(identityManager.getOrCreateUserIdentity("john")).thenReturn(johnIdentity);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event fetched = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(fetched);
+
+    AgendaEventModel model = tool.inviteUsersToAgendaEvent(EVENT_ID, List.of("john"));
+
+    assertNotNull(model);
+    verify(agendaEventAttendeeService,
+          times(1)).saveEventAttendees(any(), any(), eq(USER_IDENTITY_ID), eq(false), eq(false), any());
+  }
+
+  @Test
+  void inviteSpaceToAgendaEventSucceeds() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(SPACE_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(agendaEventAttendeeService.getEventAttendees(EVENT_ID)).thenReturn(new EventAttendeeList(Collections.emptyList()));
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event fetched = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(fetched);
+
+    AgendaEventModel model = tool.inviteSpaceToAgendaEvent(EVENT_ID, SPACE_ID);
+
+    assertNotNull(model);
+    verify(agendaEventAttendeeService,
+          times(1)).saveEventAttendees(any(), any(), eq(USER_IDENTITY_ID), eq(false), eq(false), any());
+  }
+
+  // --- date polls happy paths --------------------------------------------------
+
+  @Test
+  void createDatePollSucceedsWithRanking() throws Exception {
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(userAcl.hasAccessPermission(any(), eq("800"), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    when(identityManager.getIdentity(USER_IDENTITY_ID)).thenReturn(currentUserIdentityMock);
+    when(currentUserIdentityMock.isUser()).thenReturn(true);
+    when(currentUserIdentityMock.getRemoteId()).thenReturn(USERNAME);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(Collections.emptyList());
+    Event created = buildEvent(800L, CALENDAR_ID, START, END, EventStatus.TENTATIVE);
+    when(agendaEventService.createEvent(any(), any(), any(), any(), any(), any(), anyBoolean(), eq(USER_IDENTITY_ID)))
+                                                                                                                     .thenReturn(created);
+    when(agendaEventService.getEventById(eq(800L), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(created);
+    when(agendaEventDatePollService.getEventDateOptions(eq(800L), eq(ZoneOffset.UTC))).thenReturn(Collections.emptyList());
+
+    DatePollModel model = tool.createDatePoll(SPACE_ID,
+                                              "Team sync",
+                                              List.of("2026-07-20T09:00:00Z|2026-07-20T09:30:00Z",
+                                                      "2026-07-20T10:00:00Z|2026-07-20T10:30:00Z"),
+                                              null,
+                                              null,
+                                              true,
+                                              null);
+
+    assertNotNull(model);
+    assertEquals(800L, model.getEventId());
+  }
+
+  @Test
+  void createDatePollWithInvalidSlotFormatFails() throws Exception {
+    when(userAcl.hasPermission(any(),
+                               eq(String.valueOf(SPACE_ID)),
+                               any(),
+                               any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.createDatePoll(SPACE_ID, "poll", List.of("not-a-valid-slot"), null, null, false, null));
+  }
+
+  @Test
+  void voteDatePollSucceedsAndReturnsResultsWithVoters() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    Event event = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.TENTATIVE);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(event);
+    EventDateOption option = new EventDateOption(10L, EVENT_ID, START, END, false, true, List.of(USER_IDENTITY_ID));
+    when(agendaEventDatePollService.getEventDateOptions(eq(EVENT_ID), eq(ZoneOffset.UTC))).thenReturn(List.of(option));
+    when(identityManager.getIdentity(USER_IDENTITY_ID)).thenReturn(currentUserIdentityMock);
+    when(currentUserIdentityMock.isUser()).thenReturn(true);
+    when(currentUserIdentityMock.getRemoteId()).thenReturn(USERNAME);
+
+    DatePollModel model = tool.voteDatePoll(EVENT_ID, List.of(10L));
+
+    assertEquals(1, model.getOptions().size());
+    assertEquals(1, model.getOptions().get(0).getVoteCount());
+    assertEquals(List.of(USERNAME), model.getOptions().get(0).getVoters());
+    verify(agendaEventDatePollService, times(1)).saveEventVotes(EVENT_ID, List.of(10L), USER_IDENTITY_ID);
+  }
+
+  @Test
+  void getDatePollResultsSucceedsWithNoVoters() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    Event event = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.TENTATIVE);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(event);
+    EventDateOption option = new EventDateOption(10L, EVENT_ID, START, END, false, false, null);
+    when(agendaEventDatePollService.getEventDateOptions(eq(EVENT_ID), eq(ZoneOffset.UTC))).thenReturn(List.of(option));
+
+    DatePollModel model = tool.getDatePollResults(EVENT_ID);
+
+    assertEquals(1, model.getOptions().size());
+    assertEquals(0, model.getOptions().get(0).getVoteCount());
+    assertTrue(model.getOptions().get(0).getVoters().isEmpty());
+  }
+
+  @Test
+  void getDatePollResultsNotFoundFails() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class, () -> tool.getDatePollResults(EVENT_ID));
+  }
+
+  @Test
+  void confirmDatePollSucceeds() throws Exception {
+    EventDateOption option = new EventDateOption(10L, EVENT_ID, START, END, false, false, null);
+    when(agendaEventDatePollService.getEventDateOption(eq(10L), eq(ZoneOffset.UTC))).thenReturn(option);
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event event = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(event);
+
+    AgendaEventModel model = tool.confirmDatePoll(10L);
+
+    assertNotNull(model);
+    assertTrue(model.getConflicts().isAllAvailable());
+    verify(agendaEventService, times(1)).selectEventDateOption(EVENT_ID, 10L, USER_IDENTITY_ID);
+  }
+
+  @Test
+  void confirmDatePollNotFoundFails() {
+    when(agendaEventDatePollService.getEventDateOption(eq(10L), eq(ZoneOffset.UTC))).thenReturn(null);
+    assertThrows(ObjectNotFoundException.class, () -> tool.confirmDatePoll(10L));
+  }
+
+  // --- free/busy + suggestions --------------------------------------------------
+
+  @Test
+  void getAvailabilityMergesOverlappingBusyIntervalsAndComputesFreeBlocks() throws Exception {
+    Identity john = Mockito.mock(Identity.class);
+    when(john.getIdentityId()).thenReturn(400L);
+    when(identityManager.getOrCreateUserIdentity("john")).thenReturn(john);
+
+    Event a = buildEvent(1L,
+                        CALENDAR_ID,
+                        ZonedDateTime.of(2026, 7, 20, 9, 0, 0, 0, ZoneOffset.UTC),
+                        ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC),
+                        EventStatus.CONFIRMED);
+    Event b = buildEvent(2L,
+                        CALENDAR_ID,
+                        ZonedDateTime.of(2026, 7, 20, 9, 30, 0, 0, ZoneOffset.UTC),
+                        ZonedDateTime.of(2026, 7, 20, 10, 30, 0, 0, ZoneOffset.UTC),
+                        EventStatus.CONFIRMED);
+    Event c = buildEvent(3L,
+                        CALENDAR_ID,
+                        ZonedDateTime.of(2026, 7, 20, 14, 0, 0, 0, ZoneOffset.UTC),
+                        ZonedDateTime.of(2026, 7, 20, 15, 0, 0, 0, ZoneOffset.UTC),
+                        EventStatus.CONFIRMED);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(400L))).thenReturn(List.of(a, b, c));
+
+    List<AvailabilityModel> result =
+                                    tool.getAvailability(List.of("john"), "2026-07-20T08:00:00Z", "2026-07-20T20:00:00Z");
+
+    assertEquals(1, result.size());
+    AvailabilityModel availability = result.get(0);
+    assertEquals(2, availability.getBusy().size());
+    assertEquals(3, availability.getFree().size());
+  }
+
+  @Test
+  void getAvailabilityFullyBusyWindowYieldsNoFreeBlocks() throws Exception {
+    Identity jane = Mockito.mock(Identity.class);
+    when(jane.getIdentityId()).thenReturn(410L);
+    when(identityManager.getOrCreateUserIdentity("jane")).thenReturn(jane);
+    Event fullyBusy = buildEvent(4L,
+                                CALENDAR_ID,
+                                ZonedDateTime.of(2026, 7, 20, 8, 0, 0, 0, ZoneOffset.UTC),
+                                ZonedDateTime.of(2026, 7, 20, 10, 0, 0, 0, ZoneOffset.UTC),
+                                EventStatus.CONFIRMED);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(410L))).thenReturn(List.of(fullyBusy));
+
+    List<AvailabilityModel> result =
+                                    tool.getAvailability(List.of("jane"), "2026-07-20T08:00:00Z", "2026-07-20T10:00:00Z");
+
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).getFree().isEmpty());
+  }
+
+  @Test
+  void getAvailabilitySkipsUnknownUsernames() throws Exception {
+    when(identityManager.getOrCreateUserIdentity("ghost")).thenReturn(null);
+
+    List<AvailabilityModel> result =
+                                    tool.getAvailability(List.of("ghost"), "2026-07-20T08:00:00Z", "2026-07-20T20:00:00Z");
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void suggestMeetingTimeFindsFreeSlotsRespectingMorningConstraint() throws Exception {
+    Identity john = Mockito.mock(Identity.class);
+    when(john.getIdentityId()).thenReturn(401L);
+    when(identityManager.getOrCreateUserIdentity("john")).thenReturn(john);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(401L))).thenReturn(Collections.emptyList());
+
+    List<TimeBlockModel> suggestions = tool.suggestMeetingTime(List.of("john"),
+                                                               30,
+                                                               "2026-07-20T09:00:00Z",
+                                                               "2026-07-20T13:00:00Z",
+                                                               "mornings only please");
+
+    assertEquals(6, suggestions.size());
+  }
+
+  @Test
+  void suggestMeetingTimeWithoutConstraintsReturnsAllSlots() throws Exception {
+    Identity john = Mockito.mock(Identity.class);
+    when(john.getIdentityId()).thenReturn(401L);
+    when(identityManager.getOrCreateUserIdentity("john")).thenReturn(john);
+    when(agendaEventService.getEvents(any(), eq(ZoneOffset.UTC), eq(401L))).thenReturn(Collections.emptyList());
+
+    List<TimeBlockModel> suggestions =
+                                      tool.suggestMeetingTime(List.of("john"),
+                                                              30,
+                                                              "2026-07-20T09:00:00Z",
+                                                              "2026-07-20T13:00:00Z",
+                                                              null);
+
+    assertEquals(8, suggestions.size());
+  }
+
+  // --- attendees / response / reminders / conference / search -----------------
+
+  @Test
+  void getEventAttendeesWithoutEventIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.getEventAttendees(0L));
+  }
+
+  @Test
+  void getEventAttendeesPublicSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    Event event = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(EVENT_ID)).thenReturn(event);
+    when(agendaEventAttendeeService.getEventAttendees(EVENT_ID))
+                                                                .thenReturn(new EventAttendeeList(List.of(new EventAttendee(1L,
+                                                                                                                            0L,
+                                                                                                                            EventAttendeeResponse.ACCEPTED))));
+
+    List<AgendaEventAttendeeModel> attendees = tool.getEventAttendees(EVENT_ID);
+
+    assertEquals(1, attendees.size());
+    assertEquals(EventAttendeeResponse.ACCEPTED, attendees.get(0).getResponse());
+  }
+
+  @Test
+  void respondToAgendaEventWithoutResponseFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.respondToAgendaEvent(EVENT_ID, " ", null));
+  }
+
+  @Test
+  void respondToAgendaEventRejectsNeedsAction() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    assertThrows(IllegalArgumentException.class, () -> tool.respondToAgendaEvent(EVENT_ID, "needs_action", null));
+  }
+
+  @Test
+  void respondToAgendaEventSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    Event fetched = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(eq(EVENT_ID), eq(ZoneOffset.UTC), eq(USER_IDENTITY_ID))).thenReturn(fetched);
+
+    AgendaEventModel model = tool.respondToAgendaEvent(EVENT_ID, "tentative", "on my way");
+
+    assertNotNull(model);
+    verify(agendaEventAttendeeService,
+          times(1)).sendEventResponse(EVENT_ID, USER_IDENTITY_ID, EventAttendeeResponse.TENTATIVE);
+  }
+
+  @Test
+  void setEventRemindersSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    Event event = buildEvent(EVENT_ID, CALENDAR_ID, START, END, EventStatus.CONFIRMED);
+    when(agendaEventService.getEventById(EVENT_ID)).thenReturn(event);
+    when(agendaEventReminderService.getEventReminders(EVENT_ID,
+                                                      USER_IDENTITY_ID)).thenReturn(List.of(new EventReminder(USER_IDENTITY_ID,
+                                                                                                              30,
+                                                                                                              ReminderPeriodType.MINUTE)));
+
+    List<String> reminders = tool.setEventReminders(EVENT_ID, List.of("30 MINUTE", "1 DAY"));
+
+    assertEquals(1, reminders.size());
+    assertEquals("30 MINUTE", reminders.get(0));
+    verify(agendaEventReminderService, times(1)).saveEventReminders(eq(event), any(), eq(USER_IDENTITY_ID));
+  }
+
+  @Test
+  void setEventRemindersWithInvalidFormatFails() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    assertThrows(IllegalArgumentException.class, () -> tool.setEventReminders(EVENT_ID, List.of("garbage")));
+  }
+
+  @Test
+  void getEventConferenceSucceeds() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    EventConference conference = new EventConference();
+    conference.setType("jitsi");
+    conference.setUrl("https://meet.example/room");
+    when(agendaEventConferenceService.getEventConferences(EVENT_ID)).thenReturn(List.of(conference));
+
+    ConferenceModel model = tool.getEventConference(EVENT_ID);
+
+    assertEquals("jitsi", model.getType());
+    assertEquals("https://meet.example/room", model.getUrl());
+  }
+
+  @Test
+  void getEventConferenceReturnsEmptyModelWhenNone() throws Exception {
+    when(userAcl.hasAccessPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+    when(agendaEventConferenceService.getEventConferences(EVENT_ID)).thenReturn(Collections.emptyList());
+
+    ConferenceModel model = tool.getEventConference(EVENT_ID);
+
+    assertNull(model.getType());
+    assertNull(model.getUrl());
+  }
+
+  @Test
+  void setEventConferenceSucceedsWithUrl() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+
+    ConferenceModel model = tool.setEventConference(EVENT_ID, "https://meet.example/x", null);
+
+    assertEquals("web", model.getType());
+    assertEquals("https://meet.example/x", model.getUrl());
+    verify(agendaEventConferenceService, times(1)).saveEventConferences(eq(EVENT_ID), any());
+  }
+
+  @Test
+  void setEventConferenceWithBlankUrlRemovesConference() throws Exception {
+    when(userAcl.hasEditPermission(any(), eq(String.valueOf(EVENT_ID)), any(org.exoplatform.services.security.Identity.class))).thenReturn(true);
+
+    ConferenceModel model = tool.setEventConference(EVENT_ID, " ", null);
+
+    assertNull(model.getType());
+    assertNull(model.getUrl());
+    verify(agendaEventConferenceService, times(1)).saveEventConferences(EVENT_ID, Collections.emptyList());
+  }
+
+  @Test
+  void searchAgendaEventsSucceeds() {
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    EventSearchResult result = new EventSearchResult();
+    result.setId(EVENT_ID);
+    result.setCalendarId(CALENDAR_ID);
+    result.setCreatorId(0L);
+    result.setStart(START);
+    result.setEnd(END);
+    result.setSummary("Kickoff");
+    when(agendaEventService.search(any())).thenReturn(List.of(result));
+
+    List<AgendaEventModel> models = tool.searchAgendaEvents("kickoff", null, null, null);
+
+    assertEquals(1, models.size());
+    assertEquals("Kickoff", models.get(0).getSummary());
+  }
+
+  @Test
+  void searchAgendaEventsFiltersOutOfRangeResults() {
+    stubSpaceCalendarChain(SPACE_ID, SPACE_PRETTY_NAME, OWNER_IDENTITY_ID, CALENDAR_ID);
+    EventSearchResult result = new EventSearchResult();
+    result.setId(EVENT_ID);
+    result.setCalendarId(CALENDAR_ID);
+    result.setCreatorId(0L);
+    result.setStart(START);
+    result.setEnd(END);
+    result.setSummary("Old meeting");
+    when(agendaEventService.search(any())).thenReturn(List.of(result));
+
+    List<AgendaEventModel> models =
+                                  tool.searchAgendaEvents("meeting", "2026-08-01T00:00:00Z", "2026-08-02T00:00:00Z", null);
+
+    assertTrue(models.isEmpty());
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
## Summary
- The `feature/ai-contribution` FB CI build is failing its JaCoCo coverage gate: `agenda-services` requires a 0.64 minimum instruction-coverage ratio, and is currently at 0.60.
- Root cause: #995 added `AgendaEventMcpTool` (~1358 lines, 10 MCP tools: create/update/cancel event, date polls, free/busy, suggest-time, conflict detection, reminders, conference, search) with only guard-clause (permission/validation) tests, leaving the class at ~23% instruction coverage.
- This PR adds happy-path unit tests that exercise the actual business logic of those flows (space-by-name resolution, recurrence building, free/busy computation and merging, conflict detection, date-poll ranking/voting, attendee invites, reminders, conference links, search filtering), bringing `AgendaEventMcpTool` to ~86% coverage and `agenda-services` back above threshold at **0.6662**.
- No production code changes — test-only.

## Test plan
- [x] `mvn -pl agenda-services test -Dtest=AgendaEventMcpToolTest` — 67/67 tests pass
- [x] `mvn -pl agenda-api,agenda-services -am install -Pcoverage` — JaCoCo `check-coverage` now passes (0.6662 ≥ 0.64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)