### PR TITLE
fix: Remove right-click quick color change on agenda events - EXO-88770

### DIFF
--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -1,8 +1,6 @@
 <template>
-<div class="d-flex flex-column flex-grow-1">
   <v-calendar
     ref="calendar"
-    class="flex-grow-1"
     v-model="selectedDate"
     :events="eventsToDisplay"
     :event-color="getEventColor"
@@ -36,7 +34,7 @@
     @mousedown:day="calendarMouseDown"
     @mousemove:day="calendarMouseMove"
     @mouseup:day="calendarMouseUp"
-    @contextmenu:event="showEventColorMenu"
+    @contextmenu:event="cancelEventModification"
     @contextmenu:time="cancelEventModification"
     @contextmenu:day="cancelEventModification"
     @change="retrievePeriodEvents">
@@ -86,33 +84,6 @@
         @mousedown.stop="extendEventEndDate(event)"></div>
     </template>
   </v-calendar>
-  <v-menu
-    v-model="colorMenu"
-    :position-x="colorMenuX"
-    :position-y="colorMenuY"
-    :close-on-content-click="false"
-    absolute
-    offset-y>
-    <v-card v-if="colorMenuEvent">
-      <v-color-picker
-        v-model="colorMenuColor"
-        :swatches="$agendaUtils.EVENT_COLOR_SWATCHES"
-        class="ma-2"
-        mode="hexa"
-        show-swatches
-        flat />
-      <v-card-actions>
-        <v-spacer />
-        <v-btn :disabled="colorMenuSaving" class="btn ms-2" @click="closeColorMenu">
-          {{ $t('agenda.button.cancel') }}
-        </v-btn>
-        <v-btn :loading="colorMenuSaving" :disabled="colorMenuSaving" class="btn btn-primary ms-2" @click="applyColorMenu">
-          {{ $t('agenda.button.apply') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-menu>
-</div>
 </template>
 
 <script>
@@ -150,12 +121,6 @@ export default {
   data: () => ({
     saving: false,
     quickEvent: null,
-    colorMenu: false,
-    colorMenuEvent: null,
-    colorMenuColor: null,
-    colorMenuX: 0,
-    colorMenuY: 0,
-    colorMenuSaving: false,
     originalDragedEvent: null,
     nowDate: null,
     lang: eXo.env.portal.language,
@@ -374,39 +339,6 @@ export default {
     },
     isEventTimed(event) {
       return event && !event.allDay;
-    },
-    showEventColorMenu(eventObj) {
-      this.cancelEventModification();
-      const event = eventObj && eventObj.event || eventObj;
-      if (!event || event.type === 'remoteEvent' || !event.acl || !event.acl.canEdit) {
-        return;
-      }
-      if (eventObj.nativeEvent) {
-        eventObj.nativeEvent.preventDefault();
-        eventObj.nativeEvent.stopPropagation();
-        this.colorMenuX = eventObj.nativeEvent.clientX;
-        this.colorMenuY = eventObj.nativeEvent.clientY;
-      }
-      this.colorMenuEvent = event;
-      this.colorMenuColor = event.color || (event.calendar && event.calendar.color) || this.$agendaUtils.EVENT_COLOR_SWATCHES[0][0];
-      this.colorMenu = true;
-      return false;
-    },
-    applyColorMenu() {
-      const event = this.colorMenuEvent;
-      const newColor = this.colorMenuColor;
-      this.colorMenuSaving = true;
-      this.$eventService.updateEventFields(event, {color: newColor})
-        .then(() => this.$set(event, 'color', newColor))
-        .catch(error => console.error('Error updating event color', error))
-        .finally(() => {
-          this.colorMenuSaving = false;
-          this.closeColorMenu();
-        });
-    },
-    closeColorMenu() {
-      this.colorMenu = false;
-      this.colorMenuEvent = null;
     },
     showEvent(eventObj) {
       if (this.eventDragged || this.eventExtended) {


### PR DESCRIPTION
## What
Removes the right-click quick color change added in #1006: right-clicking an event in the calendar grid no longer opens a color picker. Right-click goes back to its previous no-op behavior (`cancelEventModification` only).

## Unaffected
- The event color picker on the event form (desktop, quick-add, mobile) — same component/palette as the space settings one.
- Calendar rendering: event background = event color, left border (5px) = calendar/space color.

## Verification
Rebuilt and redeployed on a local Docker eXo 7.3 environment: confirmed right-click on an event now does nothing (no custom menu, no browser context menu), and confirmed the event form color picker and calendar background/border rendering still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)