### PR TITLE
feat: Agenda event color picker - EXO-88770

### DIFF
--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
@@ -97,6 +97,7 @@ agenda.endTime=End time
 agenda.endDate=End date
 agenda.eventTitle=Add title
 agenda.eventLocation=Add location
+agenda.label.eventColor=Color
 agenda.addParticipants=Add participants
 agenda.chooseCalendar=Choose an agenda
 agenda.noDataLabel=No agenda found

--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_fr.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_fr.properties
@@ -97,6 +97,7 @@ agenda.endTime=Heure de fin
 agenda.endDate=Date de fin
 agenda.eventTitle=Tapez le titre de votre \u00e9v\u00e9nement ici
 agenda.eventLocation=Ajouter un lieu
+agenda.label.eventColor=Couleur
 agenda.addParticipants=Ajouter des participants
 agenda.chooseCalendar=Choisissez un agenda
 agenda.noDataLabel=Aucun agenda trouv\u00e9

--- a/agenda-webapps/src/main/webapp/skin/less/agenda.less
+++ b/agenda-webapps/src/main/webapp/skin/less/agenda.less
@@ -206,6 +206,14 @@
     .event-input {
       width: 500px;
     }
+
+    .event-color-activator {
+      cursor: pointer;
+    }
+    .event-color-swatch {
+      border: 1px solid rgba(0, 0, 0, 0.2);
+      flex: 0 0 auto;
+    }
     .webconference-event-input,.webconference-event-span {
       width: 500px;
     }
@@ -400,6 +408,7 @@
     .v-calendar {
       .editable-event {
         cursor: pointer;
+        height: 100%;
       }
       .readonly-event {
         cursor: default;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -1,6 +1,8 @@
 <template>
+<div class="d-flex flex-column flex-grow-1">
   <v-calendar
     ref="calendar"
+    class="flex-grow-1"
     v-model="selectedDate"
     :events="eventsToDisplay"
     :event-color="getEventColor"
@@ -34,7 +36,7 @@
     @mousedown:day="calendarMouseDown"
     @mousemove:day="calendarMouseMove"
     @mouseup:day="calendarMouseUp"
-    @contextmenu:event="cancelEventModification"
+    @contextmenu:event="showEventColorMenu"
     @contextmenu:time="cancelEventModification"
     @contextmenu:day="cancelEventModification"
     @change="retrievePeriodEvents">
@@ -48,7 +50,8 @@
     <template #event="{ event, timed }">
       <div
         v-if="!event || event.type !== 'remoteEvent'"
-        :class="getEventClass(event)">
+        :class="getEventClass(event)"
+        :style="{borderLeft: `5px solid ${getEventBorderColor(event)}`}">
         <strong
           :title="event.summary"
           class="text-truncate my-auto d-flex ms-2">
@@ -83,6 +86,33 @@
         @mousedown.stop="extendEventEndDate(event)"></div>
     </template>
   </v-calendar>
+  <v-menu
+    v-model="colorMenu"
+    :position-x="colorMenuX"
+    :position-y="colorMenuY"
+    :close-on-content-click="false"
+    absolute
+    offset-y>
+    <v-card v-if="colorMenuEvent">
+      <v-color-picker
+        v-model="colorMenuColor"
+        :swatches="$agendaUtils.EVENT_COLOR_SWATCHES"
+        class="ma-2"
+        mode="hexa"
+        show-swatches
+        flat />
+      <v-card-actions>
+        <v-spacer />
+        <v-btn :disabled="colorMenuSaving" class="btn ms-2" @click="closeColorMenu">
+          {{ $t('agenda.button.cancel') }}
+        </v-btn>
+        <v-btn :loading="colorMenuSaving" :disabled="colorMenuSaving" class="btn btn-primary ms-2" @click="applyColorMenu">
+          {{ $t('agenda.button.apply') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</div>
 </template>
 
 <script>
@@ -120,6 +150,12 @@ export default {
   data: () => ({
     saving: false,
     quickEvent: null,
+    colorMenu: false,
+    colorMenuEvent: null,
+    colorMenuColor: null,
+    colorMenuX: 0,
+    colorMenuY: 0,
+    colorMenuSaving: false,
     originalDragedEvent: null,
     nowDate: null,
     lang: eXo.env.portal.language,
@@ -299,6 +335,9 @@ export default {
       period.title = this.$refs.calendar.title;
       this.$root.$emit('agenda-change-period', period);
     },
+    getEventBorderColor(event) {
+      return event && event.calendar && event.calendar.color || '#2196F3';
+    },
     getEventTextColor(event) {
       const eventColor = event && (event.color || event.calendar && event.calendar.color) || '#2196F3';
       if (!event.acl || !event.acl.attendee) {
@@ -335,6 +374,39 @@ export default {
     },
     isEventTimed(event) {
       return event && !event.allDay;
+    },
+    showEventColorMenu(eventObj) {
+      this.cancelEventModification();
+      const event = eventObj && eventObj.event || eventObj;
+      if (!event || event.type === 'remoteEvent' || !event.acl || !event.acl.canEdit) {
+        return;
+      }
+      if (eventObj.nativeEvent) {
+        eventObj.nativeEvent.preventDefault();
+        eventObj.nativeEvent.stopPropagation();
+        this.colorMenuX = eventObj.nativeEvent.clientX;
+        this.colorMenuY = eventObj.nativeEvent.clientY;
+      }
+      this.colorMenuEvent = event;
+      this.colorMenuColor = event.color || (event.calendar && event.calendar.color) || this.$agendaUtils.EVENT_COLOR_SWATCHES[0][0];
+      this.colorMenu = true;
+      return false;
+    },
+    applyColorMenu() {
+      const event = this.colorMenuEvent;
+      const newColor = this.colorMenuColor;
+      this.colorMenuSaving = true;
+      this.$eventService.updateEventFields(event, {color: newColor})
+        .then(() => this.$set(event, 'color', newColor))
+        .catch(error => console.error('Error updating event color', error))
+        .finally(() => {
+          this.colorMenuSaving = false;
+          this.closeColorMenu();
+        });
+    },
+    closeColorMenu() {
+      this.colorMenu = false;
+      this.colorMenuEvent = null;
     },
     showEvent(eventObj) {
       if (this.eventDragged || this.eventExtended) {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/AgendaCalendar.vue
@@ -1,8 +1,6 @@
 <template>
-<div class="d-flex flex-column flex-grow-1">
   <v-calendar
     ref="calendar"
-    class="flex-grow-1"
     v-model="selectedDate"
     :events="eventsToDisplay"
     :event-color="getEventColor"
@@ -36,7 +34,7 @@
     @mousedown:day="calendarMouseDown"
     @mousemove:day="calendarMouseMove"
     @mouseup:day="calendarMouseUp"
-    @contextmenu:event="showEventColorMenu"
+    @contextmenu:event="cancelEventModification"
     @contextmenu:time="cancelEventModification"
     @contextmenu:day="cancelEventModification"
     @change="retrievePeriodEvents">
@@ -86,33 +84,6 @@
         @mousedown.stop="extendEventEndDate(event)"></div>
     </template>
   </v-calendar>
-  <v-menu
-    v-model="colorMenu"
-    :position-x="colorMenuX"
-    :position-y="colorMenuY"
-    :close-on-content-click="false"
-    absolute
-    offset-y>
-    <v-card v-if="colorMenuEvent">
-      <v-color-picker
-        v-model="colorMenuColor"
-        :swatches="$agendaUtils.EVENT_COLOR_SWATCHES"
-        class="ma-2"
-        mode="hexa"
-        show-swatches
-        flat />
-      <v-card-actions>
-        <v-spacer />
-        <v-btn :disabled="colorMenuSaving" class="btn ms-2" @click="closeColorMenu">
-          {{ $t('agenda.button.cancel') }}
-        </v-btn>
-        <v-btn :loading="colorMenuSaving" :disabled="colorMenuSaving" class="btn btn-primary ms-2" @click="applyColorMenu">
-          {{ $t('agenda.button.apply') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-menu>
-</div>
 </template>
 
 <script>
@@ -150,12 +121,6 @@ export default {
   data: () => ({
     saving: false,
     quickEvent: null,
-    colorMenu: false,
-    colorMenuEvent: null,
-    colorMenuColor: null,
-    colorMenuX: 0,
-    colorMenuY: 0,
-    colorMenuSaving: false,
     originalDragedEvent: null,
     nowDate: null,
     lang: eXo.env.portal.language,
@@ -374,39 +339,6 @@ export default {
     },
     isEventTimed(event) {
       return event && !event.allDay;
-    },
-    showEventColorMenu(eventObj) {
-      this.cancelEventModification();
-      const event = eventObj && eventObj.event || eventObj;
-      if (!event || event.type === 'remoteEvent' || !event.acl || !event.acl.canEdit) {
-        return;
-      }
-      if (eventObj.nativeEvent) {
-        eventObj.nativeEvent.preventDefault();
-        eventObj.nativeEvent.stopPropagation();
-        this.colorMenuX = eventObj.nativeEvent.clientX;
-        this.colorMenuY = eventObj.nativeEvent.clientY;
-      }
-      this.colorMenuEvent = event;
-      this.colorMenuColor = event.color || (event.calendar && event.calendar.color) || this.$agendaUtils.EVENT_COLOR_SWATCHES[0][0];
-      this.colorMenu = true;
-      return false;
-    },
-    applyColorMenu() {
-      const event = this.colorMenuEvent;
-      const newColor = this.colorMenuColor;
-      this.colorMenuSaving = true;
-      this.$eventService.updateEventFields(event, {color: newColor})
-        .then(() => this.$set(event, 'color', newColor))
-        .catch(error => console.error('Error updating event color', error))
-        .finally(() => {
-          this.colorMenuSaving = false;
-          this.closeColorMenu();
-        });
-    },
-    closeColorMenu() {
-      this.colorMenu = false;
-      this.colorMenuEvent = null;
     },
     showEvent(eventObj) {
       if (this.eventDragged || this.eventExtended) {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/calendar-body/mobile/AgendaTimeline.vue
@@ -32,7 +32,7 @@
                 v-for="(event, i) in limitedEventsByDates[month][eventDay]"
                 :key="i"
                 :title="event.summary"
-                :style="{background: event.color || event.calendar.color}"
+                :style="{background: event.color || event.calendar.color, borderLeft: `5px solid ${event.calendar.color || '#2196F3'}`}"
                 :class="event.type === 'remoteEvent' && 'remote-event'"
                 class="event-timeline-detail d-flex flex-column white--text px-2 py-0 mb-2 border-radius"
                 dark

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
@@ -46,6 +46,10 @@
             name="locationEvent"
             class="ignore-vuetify-classes my-3 event-input">
         </div>
+        <div class="d-flex flex-row align-center">
+          <v-icon size="20" class="icon-default-color my-auto me-12">fas fa-palette</v-icon>
+          <agenda-event-form-color-picker :event="event" />
+        </div>
         <div class="d-flex flex-row">
           <div :class="hasRecurrence ? 'flex-grow-0 pt-2' : 'my-auto'">
             <v-icon size="20" class="icon-default-color me-11">fas fa-redo</v-icon>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormColorPicker.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormColorPicker.vue
@@ -1,0 +1,103 @@
+<!--
+
+    This file is part of the Meeds project (https://meeds.io/).
+
+    Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-menu
+    ref="menu"
+    v-model="menu"
+    :close-on-content-click="false"
+    :content-class="eventColorMenuId"
+    bottom
+    left>
+    <template #activator="{ on, attrs }">
+      <div
+        :id="eventColorMenuId"
+        class="d-flex align-center event-color-activator"
+        v-bind="attrs"
+        v-on="on">
+        <v-card
+          :color="eventColor"
+          height="20"
+          width="20"
+          flat
+          class="event-color-swatch" />
+        <div class="ms-2">{{ eventColor }}</div>
+      </div>
+    </template>
+    <v-card>
+      <v-color-picker
+        v-model="newEventColor"
+        :swatches="$agendaUtils.EVENT_COLOR_SWATCHES"
+        class="ma-2"
+        mode="hexa"
+        show-swatches
+        flat />
+      <v-card-actions>
+        <v-spacer />
+        <v-btn class="btn ms-2" @click="closeMenu">
+          {{ $t('agenda.button.cancel') }}
+        </v-btn>
+        <v-btn class="btn btn-primary ms-2" @click="applyColor">
+          {{ $t('agenda.button.apply') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  props: {
+    event: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data: () => ({
+    menu: false,
+    newEventColor: null,
+  }),
+  computed: {
+    eventColor() {
+      return this.event.color || (this.event.calendar && this.event.calendar.color) || this.$agendaUtils.EVENT_COLOR_SWATCHES[0][0];
+    },
+    eventColorMenuId() {
+      return `eventColorMenu${this._uid}`;
+    },
+  },
+  watch: {
+    menu(opened) {
+      if (opened) {
+        this.newEventColor = this.eventColor;
+      }
+    },
+  },
+  methods: {
+    applyColor() {
+      this.$set(this.event, 'color', this.newEventColor);
+      this.menu = false;
+    },
+    closeMenu() {
+      this.menu = false;
+    },
+  },
+};
+</script>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -67,6 +67,10 @@
             :current-space="currentSpace"
             :conference-provider="conferenceProvider"
             icon-class="ms-3 me-4" />
+          <div class="d-flex flex-row align-center">
+            <v-icon size="20" class="icon-default-color my-auto mx-3">fas fa-palette</v-icon>
+            <agenda-event-form-color-picker :event="event" class="ms-2" />
+          </div>
           <div class="d-flex flex-row">
             <v-icon size="20" class="icon-default-color my-auto ms-3 me-4">fas fa-users</v-icon>
             <agenda-event-form-attendees

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -67,9 +67,9 @@
             :current-space="currentSpace"
             :conference-provider="conferenceProvider"
             icon-class="ms-3 me-4" />
-          <div class="d-flex flex-row align-center">
-            <v-icon size="20" class="icon-default-color my-auto mx-3">fas fa-palette</v-icon>
-            <agenda-event-form-color-picker :event="event" class="ms-2" />
+          <div class="d-flex flex-row align-center mb-2">
+            <v-icon size="20" class="icon-default-color my-auto ms-3 me-5">fas fa-palette</v-icon>
+            <agenda-event-form-color-picker :event="event" />
           </div>
           <div class="d-flex flex-row">
             <v-icon size="20" class="icon-default-color my-auto ms-3 me-4">fas fa-users</v-icon>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
@@ -75,6 +75,10 @@
           name="locationEvent"
           class="ignore-vuetify-classes my-0 location-event-input">
         <label class="font-weight-bold my-2">
+          {{ $t('agenda.label.eventColor') }}
+        </label>
+        <agenda-event-form-color-picker :event="event" />
+        <label class="font-weight-bold my-2">
           {{ $t('agenda.conference') }}
         </label>
         <agenda-event-form-conference

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/initComponents.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/initComponents.js
@@ -40,6 +40,7 @@ import AgendaEventFormAttendees from './components/event/form/AgendaEventFormAtt
 import AgendaEventFormAttendeeItem from './components/event/form/AgendaEventFormAttendeeItem.vue';
 import AgendaEventFormCalendarOwner from './components/event/form/AgendaEventFormCalendarOwner.vue';
 import AgendaEventFormConference from './components/event/form/AgendaEventFormConference.vue';
+import AgendaEventFormColorPicker from './components/event/form/AgendaEventFormColorPicker.vue';
 import AgendaEventFormAttendeesDrawer from './components/event/form/AgendaEventFormAttendeesDrawer.vue';
 import AgendaEventAttendeesAvatars from './components/event/common/AgendaEventAttendeesAvatars.vue';
 
@@ -130,6 +131,7 @@ const components = {
   'agenda-event-form-attendee-item': AgendaEventFormAttendeeItem,
   'agenda-event-form-calendar-owner': AgendaEventFormCalendarOwner,
   'agenda-event-form-conference': AgendaEventFormConference,
+  'agenda-event-form-color-picker': AgendaEventFormColorPicker,
   'agenda-event-date-poll-details': AgendaEventDatePollDetails,
   'agenda-event-date-poll-details-desktop': AgendaEventDatePollDetailsDesktop,
   'agenda-event-date-poll-details-mobile': AgendaEventDatePollDetailsMobile,

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/AgendaUtils.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/js/AgendaUtils.js
@@ -4,6 +4,14 @@ export const USER_TIMEZONE_ID = new window.Intl.DateTimeFormat().resolvedOptions
 export const TIMEZONES = [];
 export const MINIMUM_TIME_INTERVAL = 30;
 export const MINIMUM_TIME_INTERVAL_MS = MINIMUM_TIME_INTERVAL * 60 * 1000;
+// Same palette as the space settings' calendar color picker (AgendaSpaceAdministration.vue)
+export const EVENT_COLOR_SWATCHES = [
+  ['#FF0000', '#319ab3', '#f97575'],
+  ['#98cc81', '#4273c8', '#cea6ac'],
+  ['#bc99e7', '#9ee4f5', '#774ea9'],
+  ['#ffa500', '#bed67e', '#0E100F'],
+  ['#ffaacc', '#0000AA', '#000055'],
+];
 
 export function initEventForm(agendaEvent, deleteDates) {
   if (!agendaEvent.timeZoneId) {


### PR DESCRIPTION
## What
Backport to `develop` of the agenda event color picker feature and its two follow-up fixes, originally merged into `feature/ai-contribution`:
- #1006 — feat: Agenda event color picker
- #1008 — fix: Remove right-click quick color change on agenda events
- #1009 — fix: Align color field in the quick-add event form

Bundled into a single PR (rather than three) so `develop` never sees the intermediate state where the right-click quick-change existed before it was removed.

## Verification
Cherry-picked cleanly with no conflicts; commits reference their origin via `-x`. See #1006, #1008, #1009 for original manual verification.