### PR TITLE
fix: Fix agenda timeline config issue - EXO-88649

### DIFF
--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
@@ -318,7 +318,7 @@ agenda.timeline.settings.drawer.label.displayOptions=Display options
 agenda.timeline.settings.drawer.label.headerOptions=Header options
 agenda.timeline.settings.drawer.label.updateTitle=Update title
 agenda.timeline.settings.drawer.title.placeholder=Update the name
-agenda.settings.savedSuccesfully=Settings have been saved successfully
+agenda.settings.savedSuccessfully=Settings have been saved successfully
 agenda.settings.saveError=An error occurred while saving your settings
 
 agenda.timeline.seeMore=See more

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/common/AgendaEventAttendeesAvatars.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/common/AgendaEventAttendeesAvatars.vue
@@ -1,5 +1,5 @@
 <template>
-   <v-card
+  <v-card
     :min-width="avatarsWidth"
     class="transparent d-flex align-center"
     flat

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
@@ -237,11 +237,11 @@ export default {
     },
     isValidLink() {
       try {
-        return this.timelineSettings.seeMoreUrl && this.timelineSettings.seeMoreUrl !=='' && this.$utils.toLinkUrl(this.timelineSettings.seeMoreUrl, {
+        return !!(this.timelineSettings.seeMoreUrl && this.timelineSettings.seeMoreUrl !=='' && this.$utils.toLinkUrl(this.timelineSettings.seeMoreUrl, {
           urls: true,
           email: true,
           phone: true,
-        })?.length;
+        })?.length);
       } catch (e) {
         return false;
       }
@@ -264,7 +264,7 @@ export default {
     open() {
       this.timelineSettings = JSON.parse(JSON.stringify(this.$root.timelineSettings));
       if (this.timelineSettings.agendaSource === '') {
-        if (eXo.env.portal.spaceId){
+        if (eXo.env.portal.spaceId && !this.$root.standalone){
           this.timelineSettings.agendaSource = 'selectedSpaces';
           this.$spaceService.getSpaceById(eXo.env.portal.spaceId)
             .then((data) => {
@@ -293,7 +293,7 @@ export default {
         }     
       }
       if (this.timelineSettings.seeMoreUrl === '') {
-        if (eXo.env.portal.spaceId) {    
+        if (eXo.env.portal.spaceId && !this.$root.standalone) {
           this.timelineSettings.seeMoreUrl = `${eXo.env.portal.context}/s/${eXo.env.portal.spaceId}/agenda`;
         } else {
           this.timelineSettings.seeMoreUrl = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;
@@ -309,7 +309,7 @@ export default {
         this.timelineSettings.itemsNumber = 10;
       }
       if (!this.timelineSettings.agendaFilter) {
-        if (eXo.env.portal.spaceId) {  
+        if (eXo.env.portal.spaceId && !this.$root.standalone) {
           this.timelineSettings.agendaFilter = 'allEvents';
         } else {
           this.timelineSettings.agendaFilter = 'acceptedEvents';

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineSettingsDrawer.vue
@@ -284,8 +284,11 @@ export default {
                     membersCount: data.membersCount,
                   },
                 };
+                // Two distinct copies, else removing a space from the suggester
+                // mutates both lists and the drawer is considered as not
+                // modified, which keeps the save button disabled
+                this.defaultTimelineSettings.selectedSpaces = [structuredClone(space)];
                 this.timelineSettings.selectedSpaces = [space];
-                this.defaultTimelineSettings.selectedSpaces = [space];
               }
             });
         }  else {
@@ -331,7 +334,11 @@ export default {
         const formData = new FormData();
         formData.append('settings', JSON.stringify(this.timelineSettings));
         const urlParams = new URLSearchParams(formData).toString();
-        const response = await fetch(this.$root.settingsSaveUrl, {
+        // The action URL comes from <portlet:actionURL> which XML-escapes it,
+        // thus its parameters are separated by '&amp;'. They have to be
+        // restored, else only the first portal parameter is readable server
+        // side and the portlet action is dropped without saving anything.
+        const response = await fetch(this.$root.settingsSaveUrl.replaceAll('&amp;', '&'), {
           method: 'POST',
           credentials: 'include',
           headers: {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/components/AgendaTimelineWidget.vue
@@ -272,7 +272,7 @@ export default {
       } else if (this.$root.timelineSettings.agendaSource === 'allUsersSpaces'){
         this.ownerIds = [];
         return this.retrieveEventsFromStore();
-      } else if (!this.initialized && eXo.env.portal.spaceId) {
+      } else if (!this.initialized && eXo.env.portal.spaceId && !this.$root.standalone) {
         const spaceId = eXo.env.portal.spaceId;
         return this.$spaceService.getSpaceById(spaceId, 'identity')
           .then((space) => {
@@ -294,7 +294,8 @@ export default {
             this.retrieveEventsFromStore();
           });
       } else {
-        if (!eXo.env.portal.spaceId) {
+        if (!eXo.env.portal.spaceId || this.$root.standalone) {
+          this.ownerIds = [];
           this.agendaBaseLink = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/agenda`;
         }
         return this.retrieveEventsFromStore();
@@ -304,7 +305,7 @@ export default {
       this.loading = true;
       let agendaFilter = this.$root.timelineSettings.agendaFilter;
       if (!agendaFilter) {
-        if (eXo.env.portal.spaceId) {  
+        if (eXo.env.portal.spaceId && !this.$root.standalone) {
           agendaFilter = 'allEvents';
         } else {
           agendaFilter = 'acceptedEvents';

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-timeline/main.js
@@ -22,6 +22,12 @@ const lang = eXo && eXo.env.portal.language || 'en';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Agenda-${lang}.json`;
 
 export function init(appId, canEdit, settings, settingsSaveUrl, settingName, headerTitle) {
+  // When the timeline is rendered standalone (e.g. pinned in the App Center
+  // drawer through the portlet-viewer) it is not bound to the visited space,
+  // so it must keep its own configuration instead of adopting the current
+  // space context. Such a render lives inside a navigation drawer, unlike a
+  // portlet embedded in a space page (which sits in #UISiteBody).
+  const standalone = !!document.getElementById(appId)?.closest('.v-navigation-drawer');
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
   // init Vue app when locale ressources are ready
     const eventType = eXo.env.portal.spaceId ? 'allEvents' : 'myEvents';
@@ -34,7 +40,8 @@ export function init(appId, canEdit, settings, settingsSaveUrl, settingName, hea
           settingsSaveUrl,
           canEdit,
           settingName,
-          headerTitle
+          headerTitle,
+          standalone
         };
       },
       mounted() {


### PR DESCRIPTION
Prior to this change, when the agenda timeline is pinned, it wrongly fell back to the visited space, so it displayed that space's events and pre-filled its settings with it.
This change detects the standalone render and keeps the timeline's own configuration (defaulting to all user's spaces) instead of adopting the visited space.