### PR TITLE
fix: Display the calendar color as default event color - EXO-88954

### DIFF
--- a/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaCalendarServiceImpl.java
+++ b/agenda-services/src/main/java/org/exoplatform/agenda/service/AgendaCalendarServiceImpl.java
@@ -221,7 +221,7 @@ public class AgendaCalendarServiceImpl implements AgendaCalendarService {
    */
   @Override
   public Calendar createCalendarInstance(long ownerId) {
-    return new Calendar(0, ownerId, true, null, null, null, null, getRandomDefaultColor(), null);
+    return new Calendar(0, ownerId, true, null, null, null, null, getDefaultColor(ownerId), null);
   }
 
   /**
@@ -239,7 +239,7 @@ public class AgendaCalendarServiceImpl implements AgendaCalendarService {
                         null,
                         null,
                         null,
-                        getRandomDefaultColor(),
+                        getDefaultColor(ownerId),
                         new CalendarPermission(canCreateEvent, canEditCalendar, canInviteeEdit));
   }
 
@@ -380,9 +380,19 @@ public class AgendaCalendarServiceImpl implements AgendaCalendarService {
     agendaCalendarStorage.deleteCalendarById(calendarId);
   }
 
-  private String getRandomDefaultColor() {
+  /**
+   * Computes the default color of a calendar from its owner identifier, so that
+   * the color of a calendar that isn't created yet is stable: it's returned
+   * identically by any previous read of the calendar, and it's the one that will
+   * effectively be stored when the calendar gets created. Colors remain spread
+   * over the configured palette to keep distinguishing calendars from each other.
+   *
+   * @param ownerId technical identifier of the calendar owner identity
+   * @return default color of the calendar of the given owner
+   */
+  private String getDefaultColor(long ownerId) {
     int size = this.defaultColors.size();
-    int index = new Random().nextInt(size);
+    int index = (int) Math.abs(ownerId % size);
     return this.defaultColors.get(index);
   }
 

--- a/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaCalendarServiceTest.java
+++ b/agenda-services/src/test/java/org/exoplatform/agenda/service/AgendaCalendarServiceTest.java
@@ -164,6 +164,30 @@ public class AgendaCalendarServiceTest {
   }
 
   @Test
+  public void testCreateCalendarInstanceDefaultColorIsStable() {
+    List<String> colors = Arrays.asList("#111111", "#222222", "#333333");
+    InitParams initParams = new InitParams();
+    ValuesParam value = new ValuesParam();
+    value.setName("defaultColors");
+    value.setValues(new ArrayList<>(colors));
+    initParams.addParam(value);
+    AgendaCalendarServiceImpl calendarService = new AgendaCalendarServiceImpl(agendaCalendarStorage,
+                                                                             identityManager,
+                                                                             spaceService,
+                                                                             initParams);
+
+    // Same owner always gets the same color, so that the color of a calendar that
+    // isn't created yet is the one that will effectively be stored once created
+    Calendar calendar = calendarService.createCalendarInstance(4);
+    assertEquals(colors.get(1), calendar.getColor());
+    assertEquals(calendar.getColor(), calendarService.createCalendarInstance(4).getColor());
+
+    // Colors remain spread over the configured palette
+    assertEquals(colors.get(0), calendarService.createCalendarInstance(3).getColor());
+    assertEquals(colors.get(2), calendarService.createCalendarInstance(5).getColor());
+  }
+
+  @Test
   public void testGetCalendarByIdAndUsername() throws Exception { // NOSONAR
     long calendarId = 1;
     long calendarOwnerId = 2;

--- a/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
+++ b/agenda-webapps/src/main/resources/locale/portlet/Agenda_en.properties
@@ -98,6 +98,7 @@ agenda.endDate=End date
 agenda.eventTitle=Add title
 agenda.eventLocation=Add location
 agenda.label.eventColor=Color
+agenda.label.selectSpaceToChooseColor=Select a space to choose a color
 agenda.addParticipants=Add participants
 agenda.chooseCalendar=Choose an agenda
 agenda.noDataLabel=No agenda found

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/AgendaEventDialog.vue
@@ -15,6 +15,7 @@
           ref="eventForm"
           :event="event"
           :current-space="currentSpace"
+          :calendars="calendars"
           :conference-provider="conferenceProvider"
           class="fill-height event-form"
           @close="close"

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormBasicInformation.vue
@@ -48,7 +48,7 @@
         </div>
         <div class="d-flex flex-row align-center">
           <v-icon size="20" class="icon-default-color my-auto me-12">fas fa-palette</v-icon>
-          <agenda-event-form-color-picker :event="event" />
+          <agenda-event-form-color-picker :event="event" :calendars="selectedCalendars" />
         </div>
         <div class="d-flex flex-row">
           <div :class="hasRecurrence ? 'flex-grow-0 pt-2' : 'my-auto'">
@@ -156,6 +156,9 @@ export default {
     },
     eventDateOptions() {
       return this.event && this.event.dateOptions || [];
+    },
+    selectedCalendars() {
+      return this.selectedCalendar && [this.selectedCalendar] || [];
     },
   },
   watch: {

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormColorPicker.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormColorPicker.vue
@@ -25,10 +25,12 @@
     v-model="menu"
     :close-on-content-click="false"
     :content-class="eventColorMenuId"
+    :disabled="!hasCalendarOwner"
     bottom
     left>
     <template #activator="{ on, attrs }">
       <div
+        v-if="hasCalendarOwner"
         :id="eventColorMenuId"
         class="d-flex align-center event-color-activator"
         v-bind="attrs"
@@ -40,6 +42,9 @@
           flat
           class="event-color-swatch" />
         <div class="ms-2">{{ eventColor }}</div>
+      </div>
+      <div v-else class="text-light-color">
+        {{ $t('agenda.label.selectSpaceToChooseColor') }}
       </div>
     </template>
     <v-card>
@@ -70,14 +75,49 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    calendars: {
+      type: Array,
+      default: () => [],
+    },
   },
   data: () => ({
     menu: false,
     newEventColor: null,
+    calendarColor: null,
+    calendarColorResolved: false,
   }),
   computed: {
+    defaultEventColor() {
+      return this.$agendaUtils.EVENT_COLOR_SWATCHES[0][0];
+    },
+    // The default color of the palette is displayed only once it's known that no
+    // calendar color has to be displayed, else it would be displayed first and
+    // replaced afterwards by the effective color
     eventColor() {
-      return this.event.color || (this.event.calendar && this.event.calendar.color) || this.$agendaUtils.EVENT_COLOR_SWATCHES[0][0];
+      return this.event.color
+        || (this.event.calendar && this.event.calendar.color)
+        || this.calendarColor
+        || (this.calendarColorResolved && this.defaultEventColor)
+        || null;
+    },
+    calendarOwner() {
+      return this.event && this.event.calendar && this.event.calendar.owner;
+    },
+    // No color can be inherited nor chosen until the calendar owner is selected
+    hasCalendarOwner() {
+      const owner = this.calendarOwner;
+      return !!owner && (!!Number(owner.id) || !!(owner.remoteId && owner.providerId));
+    },
+    // Calendar already retrieved by the parent component, if any
+    ownerCalendar() {
+      const owner = this.calendarOwner;
+      if (!owner || !owner.remoteId || !owner.providerId) {
+        return null;
+      }
+      return this.calendars.find(calendar => calendar
+                                             && calendar.owner
+                                             && calendar.owner.remoteId === owner.remoteId
+                                             && calendar.owner.providerId === owner.providerId) || null;
     },
     eventColorMenuId() {
       return `eventColorMenu${this._uid}`;
@@ -86,11 +126,66 @@ export default {
   watch: {
     menu(opened) {
       if (opened) {
-        this.newEventColor = this.eventColor;
+        this.newEventColor = this.eventColor || this.defaultEventColor;
       }
+    },
+    calendarOwner: {
+      immediate: true,
+      handler() {
+        this.retrieveCalendarColor();
+      },
     },
   },
   methods: {
+    // When creating an event, the calendar isn't retrieved with the event,
+    // thus its color has to be retrieved from its owner to be displayed
+    // as default event color instead of the first swatch of the palette
+    retrieveCalendarColor() {
+      this.calendarColor = null;
+      this.calendarColorResolved = false;
+      const owner = this.calendarOwner;
+      if (this.event.color || (this.event.calendar && this.event.calendar.color) || !owner) {
+        this.calendarColorResolved = true;
+        return;
+      }
+      // When the parent component already retrieved the calendar, its color is
+      // displayed without any additional request, thus without any flickering
+      const ownerCalendar = this.ownerCalendar;
+      if (ownerCalendar) {
+        this.calendarColor = (Number(ownerCalendar.id) > 0 && ownerCalendar.color) || null;
+        this.calendarColorResolved = true;
+        return;
+      }
+      let ownerIdentityPromise = null;
+      if (Number(owner.id)) {
+        ownerIdentityPromise = Promise.resolve(owner);
+      } else if (owner.remoteId && owner.providerId) {
+        ownerIdentityPromise = this.$identityService.getIdentityByProviderIdAndRemoteId(owner.providerId, owner.remoteId);
+      } else {
+        // The calendar owner isn't determined yet, thus no color can be displayed
+        // until it is, else the default color of the palette would be displayed first
+        return;
+      }
+      ownerIdentityPromise
+        .then(identity => identity && identity.id && this.$calendarService.getCalendars(0, 1, false, [Number(identity.id)]))
+        .then(data => {
+          const calendar = (data && data.calendars && data.calendars.length && data.calendars[0]) || null;
+          // A calendar that isn't persisted yet is returned with a 0 id and a random
+          // color, which isn't the one that will be assigned when the event is created,
+          // thus it must not be displayed as default color.
+          // The owner is checked as well to discard an outdated result, in case the
+          // selected calendar owner changed meanwhile
+          if (calendar && Number(calendar.id) > 0 && this.calendarOwner === owner) {
+            this.calendarColor = calendar.color;
+          }
+        })
+        .catch(() => this.calendarColor = null)
+        .finally(() => {
+          if (this.calendarOwner === owner) {
+            this.calendarColorResolved = true;
+          }
+        });
+    },
     applyColor() {
       this.$set(this.event, 'color', this.newEventColor);
       this.menu = false;

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormColorPicker.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventFormColorPicker.vue
@@ -152,7 +152,7 @@ export default {
       // displayed without any additional request, thus without any flickering
       const ownerCalendar = this.ownerCalendar;
       if (ownerCalendar) {
-        this.calendarColor = (Number(ownerCalendar.id) > 0 && ownerCalendar.color) || null;
+        this.calendarColor = ownerCalendar.color || null;
         this.calendarColorResolved = true;
         return;
       }
@@ -170,12 +170,11 @@ export default {
         .then(identity => identity && identity.id && this.$calendarService.getCalendars(0, 1, false, [Number(identity.id)]))
         .then(data => {
           const calendar = (data && data.calendars && data.calendars.length && data.calendars[0]) || null;
-          // A calendar that isn't persisted yet is returned with a 0 id and a random
-          // color, which isn't the one that will be assigned when the event is created,
-          // thus it must not be displayed as default color.
-          // The owner is checked as well to discard an outdated result, in case the
-          // selected calendar owner changed meanwhile
-          if (calendar && Number(calendar.id) > 0 && this.calendarOwner === owner) {
+          // The color of a calendar that isn't created yet is the one that will
+          // effectively be used once created, thus it can be displayed as well.
+          // The owner is checked to discard an outdated result, in case the selected
+          // calendar owner changed meanwhile
+          if (calendar && this.calendarOwner === owner) {
             this.calendarColor = calendar.color;
           }
         })

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/AgendaEventQuickFormDrawer.vue
@@ -69,7 +69,7 @@
             icon-class="ms-3 me-4" />
           <div class="d-flex flex-row align-center mb-2">
             <v-icon size="20" class="icon-default-color my-auto ms-3 me-5">fas fa-palette</v-icon>
-            <agenda-event-form-color-picker :event="event" />
+            <agenda-event-form-color-picker :event="event" :calendars="calendars" />
           </div>
           <div class="d-flex flex-row">
             <v-icon size="20" class="icon-default-color my-auto ms-3 me-4">fas fa-users</v-icon>

--- a/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
+++ b/agenda-webapps/src/main/webapp/vue-app/agenda-common/components/event/form/mobile/AgendaEventMobileForm.vue
@@ -77,7 +77,7 @@
         <label class="font-weight-bold my-2">
           {{ $t('agenda.label.eventColor') }}
         </label>
-        <agenda-event-form-color-picker :event="event" />
+        <agenda-event-form-color-picker :event="event" :calendars="calendars" />
         <label class="font-weight-bold my-2">
           {{ $t('agenda.conference') }}
         </label>
@@ -129,6 +129,10 @@ export default {
     currentSpace: {
       type: Object,
       default: () => null,
+    },
+    calendars: {
+      type: Array,
+      default: () => [],
     },
     conferenceProvider: {
       type: Object,


### PR DESCRIPTION
## Problem

When creating an event, the color picker displayed the first swatch of the palette (`#FF0000`) instead of the color defined in the space settings, while the created event actually took the calendar color.

`AgendaEventFormColorPicker` resolved the displayed color as `event.color || event.calendar.color || EVENT_COLOR_SWATCHES[0][0]`. A new event is built with `calendar: { owner: {} }` and its calendar is never retrieved, so `event.calendar.color` was always undefined and the palette fallback was always used.

## Changes

`AgendaEventFormColorPicker` now resolves the calendar of the selected owner and displays its color as the default one:

- **No request when the calendar is already loaded.** The parent components already hold it, so the `calendars` list is passed down to the four entry points — quick add drawer, complete form, mobile form and timeline widget. The color is then known on the first render, without any flickering.
- **Fallback resolution** through the owner identity and its calendar when the list doesn't hold it, e.g. when the owner is changed in the suggester. An outdated response is discarded if the selected owner changed meanwhile.
- **A calendar that isn't persisted yet is ignored.** `GET /v1/agenda/calendars` returns, for an owner without any calendar, a non persisted calendar with a `0` id and a *random* color — which is not the one the server assigns when the calendar gets created at first event creation. Displaying it would promise a color the event won't get.
- **The palette fallback is only used once it's known that no calendar color has to be displayed**, so it's never displayed as a waiting value and replaced afterwards.
- **As long as no space is selected**, the swatch is replaced by a `Select a space to choose a color` label and the picker is disabled, since no color can be inherited nor chosen at that point. New i18n key `agenda.label.selectSpaceToChooseColor`, added to `Agenda_en.properties` only, other languages being handled by Crowdin.

Nothing is ever written: the event color stays empty unless the user picks one, and the space settings color is left untouched.

## Tests

Manually tested on a local eXo 7.3 with this branch deployed (JS, skin and i18n):

- Space with a calendar color set → the quick add drawer displays that color immediately, no flickering, and the created event keeps it.
- Space color changed in the space settings → the drawer displays the new color, and the space settings color is unchanged after creating an event.
- No space selected in the complete form → the label is displayed and the picker can't be opened.
- Existing event with its own color → unchanged, its own color is displayed.

`eslint` passes with no error and the webpack build is clean.
